### PR TITLE
CHEF-29: Implement home screen UI, navigator, define project structure

### DIFF
--- a/.idea/deploymentTargetDropDown.xml
+++ b/.idea/deploymentTargetDropDown.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="deploymentTargetDropDown">
+    <value>
+      <entry key="app">
+        <State />
+      </entry>
+    </value>
+  </component>
+</project>

--- a/.idea/gradle.xml
+++ b/.idea/gradle.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project version="4">
+  <component name="GradleMigrationSettings" migrationVersion="1" />
   <component name="GradleSettings">
     <option name="linkedExternalProjectsSettings">
       <GradleProjectSettings>

--- a/.idea/inspectionProfiles/Project_Default.xml
+++ b/.idea/inspectionProfiles/Project_Default.xml
@@ -1,0 +1,41 @@
+<component name="InspectionProjectProfileManager">
+  <profile version="1.0">
+    <option name="myName" value="Project Default" />
+    <inspection_tool class="PreviewAnnotationInFunctionWithParameters" enabled="true" level="ERROR" enabled_by_default="true">
+      <option name="composableFile" value="true" />
+      <option name="previewFile" value="true" />
+    </inspection_tool>
+    <inspection_tool class="PreviewApiLevelMustBeValid" enabled="true" level="ERROR" enabled_by_default="true">
+      <option name="composableFile" value="true" />
+      <option name="previewFile" value="true" />
+    </inspection_tool>
+    <inspection_tool class="PreviewDimensionRespectsLimit" enabled="true" level="WARNING" enabled_by_default="true">
+      <option name="composableFile" value="true" />
+      <option name="previewFile" value="true" />
+    </inspection_tool>
+    <inspection_tool class="PreviewFontScaleMustBeGreaterThanZero" enabled="true" level="ERROR" enabled_by_default="true">
+      <option name="composableFile" value="true" />
+      <option name="previewFile" value="true" />
+    </inspection_tool>
+    <inspection_tool class="PreviewMultipleParameterProviders" enabled="true" level="ERROR" enabled_by_default="true">
+      <option name="composableFile" value="true" />
+      <option name="previewFile" value="true" />
+    </inspection_tool>
+    <inspection_tool class="PreviewMustBeTopLevelFunction" enabled="true" level="ERROR" enabled_by_default="true">
+      <option name="composableFile" value="true" />
+      <option name="previewFile" value="true" />
+    </inspection_tool>
+    <inspection_tool class="PreviewNeedsComposableAnnotation" enabled="true" level="ERROR" enabled_by_default="true">
+      <option name="composableFile" value="true" />
+      <option name="previewFile" value="true" />
+    </inspection_tool>
+    <inspection_tool class="PreviewNotSupportedInUnitTestFiles" enabled="true" level="ERROR" enabled_by_default="true">
+      <option name="composableFile" value="true" />
+      <option name="previewFile" value="true" />
+    </inspection_tool>
+    <inspection_tool class="PreviewPickerAnnotation" enabled="true" level="ERROR" enabled_by_default="true">
+      <option name="composableFile" value="true" />
+      <option name="previewFile" value="true" />
+    </inspection_tool>
+  </profile>
+</component>

--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -1,4 +1,3 @@
-<?xml version="1.0" encoding="UTF-8"?>
 <project version="4">
   <component name="ExternalStorageConfigurationManager" enabled="true" />
   <component name="ProjectRootManager" version="2" languageLevel="JDK_17" default="true" project-jdk-name="jbr-17" project-jdk-type="JavaSDK">

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -66,4 +66,9 @@ dependencies {
     androidTestImplementation("androidx.compose.ui:ui-test-junit4")
     debugImplementation("androidx.compose.ui:ui-tooling")
     debugImplementation("androidx.compose.ui:ui-test-manifest")
+
+    implementation("androidx.navigation:navigation-compose:2.7.7")
+    implementation("androidx.lifecycle:lifecycle-viewmodel-compose:2.7.0")
+    implementation("androidx.compose.material:material-icons-extended:1.6.2")
+    implementation("io.coil-kt:coil-compose:2.6.0")
 }

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -1,8 +1,9 @@
 <?xml version="1.0" encoding="utf-8"?>
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:tools="http://schemas.android.com/tools">
-
+    
     <application
+        android:name=".ChefsKissApplication"
         android:allowBackup="true"
         android:dataExtractionRules="@xml/data_extraction_rules"
         android:fullBackupContent="@xml/backup_rules"

--- a/app/src/main/java/com/javainiai/chefskiss/ChefsKissApplication.kt
+++ b/app/src/main/java/com/javainiai/chefskiss/ChefsKissApplication.kt
@@ -1,0 +1,12 @@
+package com.javainiai.chefskiss
+
+import android.app.Application
+import com.javainiai.chefskiss.data.ChefsKissAppContainer
+
+class ChefsKissApplication : Application() {
+    lateinit var container: ChefsKissAppContainer
+    override fun onCreate() {
+        super.onCreate()
+        container = ChefsKissAppContainer(this)
+    }
+}

--- a/app/src/main/java/com/javainiai/chefskiss/MainActivity.kt
+++ b/app/src/main/java/com/javainiai/chefskiss/MainActivity.kt
@@ -3,13 +3,7 @@ package com.javainiai.chefskiss
 import android.os.Bundle
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
-import androidx.compose.foundation.layout.fillMaxSize
-import androidx.compose.material3.MaterialTheme
-import androidx.compose.material3.Surface
-import androidx.compose.material3.Text
-import androidx.compose.runtime.Composable
-import androidx.compose.ui.Modifier
-import androidx.compose.ui.tooling.preview.Preview
+import com.javainiai.chefskiss.ui.ChefsKissApp
 import com.javainiai.chefskiss.ui.theme.ChefsKissTheme
 
 class MainActivity : ComponentActivity() {
@@ -17,30 +11,8 @@ class MainActivity : ComponentActivity() {
         super.onCreate(savedInstanceState)
         setContent {
             ChefsKissTheme {
-                // A surface container using the 'background' color from the theme
-                Surface(
-                    modifier = Modifier.fillMaxSize(),
-                    color = MaterialTheme.colorScheme.background
-                ) {
-                    Greeting("Android")
-                }
+                ChefsKissApp()
             }
         }
-    }
-}
-
-@Composable
-fun Greeting(name: String, modifier: Modifier = Modifier) {
-    Text(
-        text = "Hello $name!",
-        modifier = modifier
-    )
-}
-
-@Preview(showBackground = true)
-@Composable
-fun GreetingPreview() {
-    ChefsKissTheme {
-        Greeting("Android")
     }
 }

--- a/app/src/main/java/com/javainiai/chefskiss/data/AppContainer.kt
+++ b/app/src/main/java/com/javainiai/chefskiss/data/AppContainer.kt
@@ -1,0 +1,11 @@
+package com.javainiai.chefskiss.data
+
+import android.content.Context
+
+interface AppContainer {
+
+}
+
+class ChefsKissAppContainer(private val context: Context) : AppContainer {
+
+}

--- a/app/src/main/java/com/javainiai/chefskiss/data/Recipe.kt
+++ b/app/src/main/java/com/javainiai/chefskiss/data/Recipe.kt
@@ -1,0 +1,12 @@
+package com.javainiai.chefskiss.data
+
+import android.net.Uri
+
+data class Recipe(
+    val title: String,
+    val description: String,
+    val cookingTime: Int,
+    val rating: Int,
+    val favorite: Boolean,
+    val imagePath: Uri
+)

--- a/app/src/main/java/com/javainiai/chefskiss/ui/AppViewModelProvider.kt
+++ b/app/src/main/java/com/javainiai/chefskiss/ui/AppViewModelProvider.kt
@@ -1,0 +1,23 @@
+package com.javainiai.chefskiss.ui
+
+import androidx.lifecycle.ViewModelProvider
+import androidx.lifecycle.viewmodel.CreationExtras
+import androidx.lifecycle.viewmodel.initializer
+import androidx.lifecycle.viewmodel.viewModelFactory
+import com.javainiai.chefskiss.ChefsKissApplication
+import com.javainiai.chefskiss.ui.homescreen.HomeScreenViewModel
+
+object AppViewModelProvider {
+    val Factory = viewModelFactory {
+        initializer {
+            HomeScreenViewModel()
+        }
+    }
+}
+
+/**
+ * Extension function to queries for [Application] object and returns an instance of
+ * [ChefsKissApplication].
+ */
+fun CreationExtras.chefsKissApplication(): ChefsKissApplication =
+    (this[ViewModelProvider.AndroidViewModelFactory.APPLICATION_KEY] as ChefsKissApplication)

--- a/app/src/main/java/com/javainiai/chefskiss/ui/ChefsKissApp.kt
+++ b/app/src/main/java/com/javainiai/chefskiss/ui/ChefsKissApp.kt
@@ -1,0 +1,85 @@
+package com.javainiai.chefskiss.ui
+
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Home
+import androidx.compose.material.icons.filled.Restaurant
+import androidx.compose.material.icons.filled.ShoppingBasket
+import androidx.compose.material3.DrawerValue
+import androidx.compose.material3.Icon
+import androidx.compose.material3.ModalDrawerSheet
+import androidx.compose.material3.ModalNavigationDrawer
+import androidx.compose.material3.NavigationDrawerItem
+import androidx.compose.material3.Text
+import androidx.compose.material3.rememberDrawerState
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+import androidx.navigation.NavHostController
+import androidx.navigation.compose.rememberNavController
+import com.javainiai.chefskiss.ui.navigation.ChefsKissNavHost
+
+@Composable
+fun ChefsKissApp(
+    modifier: Modifier = Modifier,
+    navController: NavHostController = rememberNavController(),
+) {
+    val drawerState = rememberDrawerState(initialValue = DrawerValue.Closed)
+    ModalNavigationDrawer(
+        modifier = modifier,
+        drawerState = drawerState,
+        drawerContent = { ChefsKissDrawerSheet() }) {
+        ChefsKissNavHost(drawerState = drawerState, navController = navController)
+    }
+}
+
+
+@Composable
+fun ChefsKissDrawerSheet(modifier: Modifier = Modifier) {
+    ModalDrawerSheet(modifier = modifier) {
+        Text(text = "Chef's Kiss", modifier = Modifier.padding(16.dp))
+        NavigationDrawerItem(
+            label = {
+                Row {
+                    Icon(
+                        imageVector = Icons.Default.Home,
+                        contentDescription = "Home",
+                        modifier = Modifier.padding(end = 8.dp)
+                    )
+                    Text(text = "Home")
+                }
+            },
+            selected = true,
+            onClick = { /*TODO*/ }
+        )
+        NavigationDrawerItem(
+            label = {
+                Row {
+                    Icon(
+                        imageVector = Icons.Default.Restaurant,
+                        contentDescription = "Meal Planner",
+                        modifier = Modifier.padding(end = 8.dp)
+                    )
+                    Text(text = "Meal Planner")
+                }
+            },
+            selected = false,
+            onClick = { /*TODO*/ }
+        )
+        NavigationDrawerItem(
+            label = {
+                Row {
+                    Icon(
+                        imageVector = Icons.Default.ShoppingBasket,
+                        contentDescription = "Shopping List",
+                        modifier = Modifier.padding(end = 8.dp)
+                    )
+                    Text(text = "Shopping List")
+                }
+            },
+            selected = false,
+            onClick = { /*TODO*/ }
+        )
+    }
+}

--- a/app/src/main/java/com/javainiai/chefskiss/ui/homescreen/HomeScreen.kt
+++ b/app/src/main/java/com/javainiai/chefskiss/ui/homescreen/HomeScreen.kt
@@ -1,0 +1,192 @@
+package com.javainiai.chefskiss.ui.homescreen
+
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Add
+import androidx.compose.material.icons.filled.Favorite
+import androidx.compose.material.icons.filled.FavoriteBorder
+import androidx.compose.material.icons.filled.History
+import androidx.compose.material.icons.filled.Menu
+import androidx.compose.material.icons.filled.Search
+import androidx.compose.material.icons.filled.Star
+import androidx.compose.material.icons.filled.Timer
+import androidx.compose.material3.BottomAppBar
+import androidx.compose.material3.ButtonDefaults
+import androidx.compose.material3.Card
+import androidx.compose.material3.CardDefaults
+import androidx.compose.material3.CenterAlignedTopAppBar
+import androidx.compose.material3.DrawerState
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.FilledTonalButton
+import androidx.compose.material3.Icon
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.SearchBar
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.unit.dp
+import androidx.lifecycle.viewmodel.compose.viewModel
+import coil.compose.AsyncImage
+import com.javainiai.chefskiss.data.Recipe
+import com.javainiai.chefskiss.ui.AppViewModelProvider
+import com.javainiai.chefskiss.ui.navigation.NavigationDestination
+import kotlinx.coroutines.launch
+
+object HomeScreenDestination : NavigationDestination {
+    override val route = "home"
+}
+
+@Composable
+fun HomeScreen(
+    drawerState: DrawerState,
+    modifier: Modifier = Modifier,
+    viewModel: HomeScreenViewModel = viewModel(factory = AppViewModelProvider.Factory)
+) {
+    val coroutineScope = rememberCoroutineScope()
+
+    Scaffold(modifier = modifier,
+        topBar = { SearchTopBar(onMenuClick = { coroutineScope.launch { drawerState.open() } }) },
+        bottomBar = { RecipeBottomBar({ /* TODO */ }, { /* TODO */ }, { /* TODO */ }) }
+    ) { padding ->
+        LazyColumn(contentPadding = padding, horizontalAlignment = Alignment.CenterHorizontally) {
+            /* TODO */
+        }
+    }
+}
+
+@Composable
+fun RecipeCard(recipe: Recipe, modifier: Modifier = Modifier) {
+    Card(
+        modifier = modifier,
+        colors = CardDefaults.cardColors(containerColor = MaterialTheme.colorScheme.surface)
+    ) {
+        Row(
+            modifier = Modifier
+                .padding(8.dp)
+                .fillMaxWidth(),
+            verticalAlignment = Alignment.CenterVertically
+        ) {
+            AsyncImage(
+                model = recipe.imagePath,
+                contentDescription = null,
+                modifier = Modifier
+                    .padding(4.dp)
+                    .size(64.dp)
+                    .clip(RoundedCornerShape(4.dp)),
+                contentScale = ContentScale.Crop
+            )
+            Column(modifier = Modifier.padding(8.dp)) {
+                Text(text = recipe.title, maxLines = 1)
+                Row {
+                    Icon(imageVector = Icons.Default.Timer, contentDescription = "Time to cook")
+                    Text(
+                        text = String.format(
+                            "%02d:%02d",
+                            recipe.cookingTime / 60,
+                            recipe.cookingTime % 60
+                        )
+                    )
+                    Icon(imageVector = Icons.Default.Star, contentDescription = "Rating")
+                    Text(text = recipe.rating.toString())
+                }
+            }
+            Spacer(modifier = Modifier.weight(1f))
+            Icon(
+                imageVector = if (recipe.favorite) Icons.Default.Favorite else Icons.Default.FavoriteBorder,
+                contentDescription = "Favorite recipe"
+            )
+        }
+    }
+}
+
+
+@Composable
+fun RecipeBottomBar(
+    recentOnClick: () -> Unit,
+    addOnClick: () -> Unit,
+    favoritesOnClick: () -> Unit,
+    modifier: Modifier = Modifier
+) {
+    BottomAppBar(modifier = modifier) {
+        Row {
+            Spacer(modifier = Modifier.weight(1f))
+            Column(horizontalAlignment = Alignment.CenterHorizontally) {
+                FilledTonalButton(
+                    onClick = recentOnClick,
+                    colors = ButtonDefaults.filledTonalButtonColors(containerColor = MaterialTheme.colorScheme.secondaryContainer)
+                ) {
+                    Icon(imageVector = Icons.Default.History, contentDescription = "Recent recipes")
+                }
+                Text(text = "Recent")
+            }
+            Spacer(modifier = Modifier.weight(1f))
+            Column(horizontalAlignment = Alignment.CenterHorizontally) {
+                FilledTonalButton(
+                    onClick = addOnClick,
+                    colors = ButtonDefaults.filledTonalButtonColors(containerColor = MaterialTheme.colorScheme.background)
+                ) {
+                    Icon(imageVector = Icons.Default.Add, contentDescription = "Add recipe")
+                }
+                Text(text = "Add")
+            }
+            Spacer(modifier = Modifier.weight(1f))
+            Column(horizontalAlignment = Alignment.CenterHorizontally) {
+                FilledTonalButton(
+                    onClick = favoritesOnClick,
+                    colors = ButtonDefaults.filledTonalButtonColors(containerColor = MaterialTheme.colorScheme.background)
+                ) {
+                    Icon(
+                        imageVector = Icons.Default.Favorite,
+                        contentDescription = "Favorite recipes"
+                    )
+                }
+                Text(text = "Favorites")
+            }
+            Spacer(modifier = Modifier.weight(1f))
+        }
+    }
+}
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun SearchTopBar(onMenuClick: () -> Unit) {
+    CenterAlignedTopAppBar(
+        title = {
+            SearchBar(
+                query = "",
+                onQueryChange = {},
+                onSearch = {},
+                active = false,
+                onActiveChange = {},
+                trailingIcon = {
+                    Icon(
+                        imageVector = Icons.Default.Search,
+                        contentDescription = "Search"
+                    )
+                },
+                leadingIcon = {
+                    Icon(
+                        imageVector = Icons.Default.Menu,
+                        contentDescription = "Navigation drawer",
+                        modifier = Modifier.clickable { onMenuClick() })
+                },
+                placeholder = { Text(text = "Search") }
+            ) {}
+        },
+        modifier = Modifier.height(70.dp)
+    )
+}

--- a/app/src/main/java/com/javainiai/chefskiss/ui/homescreen/HomeScreenViewModel.kt
+++ b/app/src/main/java/com/javainiai/chefskiss/ui/homescreen/HomeScreenViewModel.kt
@@ -1,0 +1,8 @@
+package com.javainiai.chefskiss.ui.homescreen
+
+import androidx.lifecycle.ViewModel
+
+
+class HomeScreenViewModel : ViewModel() {
+
+}

--- a/app/src/main/java/com/javainiai/chefskiss/ui/navigation/ChefsKissNavHost.kt
+++ b/app/src/main/java/com/javainiai/chefskiss/ui/navigation/ChefsKissNavHost.kt
@@ -1,0 +1,28 @@
+package com.javainiai.chefskiss.ui.navigation
+
+import androidx.compose.material3.DrawerState
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.navigation.NavHostController
+import androidx.navigation.compose.NavHost
+import androidx.navigation.compose.composable
+import com.javainiai.chefskiss.ui.homescreen.HomeScreen
+import com.javainiai.chefskiss.ui.homescreen.HomeScreenDestination
+
+@Composable
+fun ChefsKissNavHost(
+    drawerState: DrawerState,
+    navController: NavHostController,
+    modifier: Modifier = Modifier
+) {
+    NavHost(
+        navController = navController,
+        startDestination = HomeScreenDestination.route,
+        modifier = modifier
+    ) {
+        composable(route = HomeScreenDestination.route) {
+            HomeScreen(drawerState)
+        }
+    }
+
+}

--- a/app/src/main/java/com/javainiai/chefskiss/ui/navigation/NavigationDestination.kt
+++ b/app/src/main/java/com/javainiai/chefskiss/ui/navigation/NavigationDestination.kt
@@ -1,0 +1,5 @@
+package com.javainiai.chefskiss.ui.navigation
+
+interface NavigationDestination {
+    val route: String
+}

--- a/app/src/main/java/com/javainiai/chefskiss/ui/theme/Theme.kt
+++ b/app/src/main/java/com/javainiai/chefskiss/ui/theme/Theme.kt
@@ -57,8 +57,9 @@ fun ChefsKissTheme(
     if (!view.isInEditMode) {
         SideEffect {
             val window = (view.context as Activity).window
-            window.statusBarColor = colorScheme.primary.toArgb()
-            WindowCompat.getInsetsController(window, view).isAppearanceLightStatusBars = darkTheme
+            window.statusBarColor = colorScheme.surface.toArgb()
+            window.navigationBarColor = colorScheme.surface.toArgb()
+            WindowCompat.getInsetsController(window, view).isAppearanceLightStatusBars = !darkTheme
         }
     }
 


### PR DESCRIPTION
Implemented the home screen UI with some changes. Alongside added a navigator. This should define the overall project structure. No recipes visible in the list yet because the database still needs to be set up to load them.

Screenshots:

![image](https://github.com/dov-vai/ChefsKiss/assets/160327869/6db14b3d-91a1-475a-9c30-6a173c2552ee)
![image](https://github.com/dov-vai/ChefsKiss/assets/160327869/16cc7db3-8898-4ee0-9af3-87c95a2fd507)
