### PR TITLE
CHEF-3: Implement recipe adding screen

### DIFF
--- a/.idea/deploymentTargetDropDown.xml
+++ b/.idea/deploymentTargetDropDown.xml
@@ -3,7 +3,20 @@
   <component name="deploymentTargetDropDown">
     <value>
       <entry key="app">
-        <State />
+        <State>
+          <targetSelectedWithDropDown>
+            <Target>
+              <type value="QUICK_BOOT_TARGET" />
+              <deviceKey>
+                <Key>
+                  <type value="VIRTUAL_DEVICE_PATH" />
+                  <value value="$USER_HOME$/.android/avd/Pixel_8_Pro_API_34.avd" />
+                </Key>
+              </deviceKey>
+            </Target>
+          </targetSelectedWithDropDown>
+          <timeTargetWasSelectedWithDropDown value="2024-03-03T18:51:09.355244774Z" />
+        </State>
       </entry>
     </value>
   </component>

--- a/app/src/main/java/com/javainiai/chefskiss/data/AppContainer.kt
+++ b/app/src/main/java/com/javainiai/chefskiss/data/AppContainer.kt
@@ -16,7 +16,8 @@ interface AppContainer {
 
 class ChefsKissAppContainer(private val context: Context) : AppContainer {
     override val recipesRepository: RecipesRepository by lazy {
-        OfflineRecipesRepository(RecipeDatabase.getDatabase(context).RecipeDao())
+        val database = RecipeDatabase.getDatabase(context)
+        OfflineRecipesRepository(database.RecipeDao(), database.IngredientDao())
     }
     override val ingredientsRepository: IngredientsRepository by lazy {
         OfflineIngredientsRepository(RecipeDatabase.getDatabase(context).IngredientDao())

--- a/app/src/main/java/com/javainiai/chefskiss/data/RecipeDatabase.kt
+++ b/app/src/main/java/com/javainiai/chefskiss/data/RecipeDatabase.kt
@@ -1,9 +1,12 @@
 package com.javainiai.chefskiss.data
 
 import android.content.Context
+import android.net.Uri
 import androidx.room.Database
 import androidx.room.Room
 import androidx.room.RoomDatabase
+import androidx.room.TypeConverter
+import androidx.room.TypeConverters
 import com.javainiai.chefskiss.data.ingredient.Ingredient
 import com.javainiai.chefskiss.data.ingredient.IngredientDao
 import com.javainiai.chefskiss.data.recipe.Recipe
@@ -11,11 +14,25 @@ import com.javainiai.chefskiss.data.recipe.RecipeDao
 import com.javainiai.chefskiss.data.tag.Tag
 import com.javainiai.chefskiss.data.tag.TagDao
 
+class Converters {
+    @TypeConverter
+    fun fromString(value: String?): Uri? {
+        return if (value == null) null else Uri.parse(value)
+    }
+
+    @TypeConverter
+    fun toString(uri: Uri?): String? {
+        return uri?.toString()
+    }
+}
+
+
 @Database(
     entities = [Recipe::class, Ingredient::class, Tag::class],
     version = 1,
     exportSchema = false
 )
+@TypeConverters(Converters::class)
 abstract class RecipeDatabase : RoomDatabase() {
     abstract fun RecipeDao(): RecipeDao
     abstract fun IngredientDao(): IngredientDao

--- a/app/src/main/java/com/javainiai/chefskiss/data/ingredient/Ingredient.kt
+++ b/app/src/main/java/com/javainiai/chefskiss/data/ingredient/Ingredient.kt
@@ -1,15 +1,29 @@
 package com.javainiai.chefskiss.data.ingredient
 
+import androidx.room.ColumnInfo
 import androidx.room.Entity
+import androidx.room.ForeignKey
 import androidx.room.PrimaryKey
+import com.javainiai.chefskiss.data.recipe.Recipe
 
-@Entity(tableName = "ingredients")
+@Entity(
+    tableName = "ingredients",
+    foreignKeys = [
+        ForeignKey(
+            entity = Recipe::class,
+            parentColumns = arrayOf("id"),
+            childColumns = arrayOf("recipeId"),
+            onDelete = ForeignKey.CASCADE
+        )
+    ]
+)
 data class Ingredient(
     @PrimaryKey(autoGenerate = true)
     val id: Int = 0,
+    @ColumnInfo(index = true)
     val recipeId: Int,
     val name: String,
-    val size: Int,
+    val size: Float,
     val unit: String,
     val allergen: Boolean
 )

--- a/app/src/main/java/com/javainiai/chefskiss/data/ingredient/IngredientDao.kt
+++ b/app/src/main/java/com/javainiai/chefskiss/data/ingredient/IngredientDao.kt
@@ -7,6 +7,7 @@ import androidx.room.OnConflictStrategy
 import androidx.room.Query
 import androidx.room.Update
 import kotlinx.coroutines.flow.Flow
+
 @Dao
 interface IngredientDao {
     @Insert(onConflict = OnConflictStrategy.IGNORE)

--- a/app/src/main/java/com/javainiai/chefskiss/data/recipe/OfflineRecipesRepository.kt
+++ b/app/src/main/java/com/javainiai/chefskiss/data/recipe/OfflineRecipesRepository.kt
@@ -1,12 +1,28 @@
 package com.javainiai.chefskiss.data.recipe
 
+import com.javainiai.chefskiss.data.ingredient.Ingredient
+import com.javainiai.chefskiss.data.ingredient.IngredientDao
 import kotlinx.coroutines.flow.Flow
 
-class OfflineRecipesRepository(private val recipeDao: RecipeDao) : RecipesRepository {
+class OfflineRecipesRepository(
+    private val recipeDao: RecipeDao,
+    private val ingredientDao: IngredientDao
+) : RecipesRepository {
     override fun getAllRecipesStream(): Flow<List<Recipe>> = recipeDao.getAllRecipes()
     override fun getRecipeStream(id: Int): Flow<Recipe?> = recipeDao.getRecipe(id)
     override fun getRecentRecipes(): Flow<List<Recipe>> = recipeDao.getRecentRecipes()
-    override suspend fun insertRecipe(recipe: Recipe) = recipeDao.insert(recipe)
+    override suspend fun insertRecipe(recipe: Recipe): Long = recipeDao.insert(recipe)
+    override suspend fun insertRecipeWithIngredients(
+        recipe: Recipe,
+        ingredients: List<Ingredient>
+    ) {
+        val recipeId = insertRecipe(recipe)
+
+        for (ingredient in ingredients) {
+            ingredientDao.insert(ingredient.copy(recipeId = recipeId.toInt()))
+        }
+    }
+
     override suspend fun deleteRecipe(recipe: Recipe) = recipeDao.delete(recipe)
     override suspend fun updateRecipe(recipe: Recipe) = recipeDao.update(recipe)
 }

--- a/app/src/main/java/com/javainiai/chefskiss/data/recipe/Recipe.kt
+++ b/app/src/main/java/com/javainiai/chefskiss/data/recipe/Recipe.kt
@@ -11,6 +11,7 @@ data class Recipe(
     val title: String,
     val description: String,
     val cookingTime: Int,
+    val servings: Int,
     val rating: Int,
     val favorite: Boolean,
     val imagePath: Uri

--- a/app/src/main/java/com/javainiai/chefskiss/data/recipe/RecipeDao.kt
+++ b/app/src/main/java/com/javainiai/chefskiss/data/recipe/RecipeDao.kt
@@ -5,13 +5,19 @@ import androidx.room.Delete
 import androidx.room.Insert
 import androidx.room.OnConflictStrategy
 import androidx.room.Query
+import androidx.room.Transaction
 import androidx.room.Update
+import com.javainiai.chefskiss.data.ingredient.Ingredient
 import kotlinx.coroutines.flow.Flow
 
 @Dao
 interface RecipeDao {
     @Insert(onConflict = OnConflictStrategy.IGNORE)
-    suspend fun insert(item: Recipe)
+    suspend fun insert(item: Recipe): Long
+
+    @Transaction
+    @Insert
+    suspend fun insert(item: Recipe, ingredients: List<Ingredient>)
 
     @Update
     suspend fun update(item: Recipe)
@@ -22,7 +28,8 @@ interface RecipeDao {
     @Query("SELECT * from recipes WHERE id = :id")
     fun getRecipe(id: Int): Flow<Recipe>
 
-    @Query("SELECT * from recipes ORDER BY title ASC")
+    @Transaction
+    @Query("SELECT * from recipes")
     fun getAllRecipes(): Flow<List<Recipe>>
 
     @Query("SELECT * from recipes ORDER BY id DESC")

--- a/app/src/main/java/com/javainiai/chefskiss/data/recipe/RecipeWithIngredients.kt
+++ b/app/src/main/java/com/javainiai/chefskiss/data/recipe/RecipeWithIngredients.kt
@@ -1,0 +1,15 @@
+package com.javainiai.chefskiss.data.recipe
+
+import androidx.room.Embedded
+import androidx.room.Relation
+import com.javainiai.chefskiss.data.ingredient.Ingredient
+
+data class RecipeWithIngredients(
+    @Embedded
+    val recipe: Recipe,
+    @Relation(
+        parentColumn = "id",
+        entityColumn = "recipeId"
+    )
+    val ingredients: List<Ingredient>
+)

--- a/app/src/main/java/com/javainiai/chefskiss/data/recipe/RecipesRepository.kt
+++ b/app/src/main/java/com/javainiai/chefskiss/data/recipe/RecipesRepository.kt
@@ -1,12 +1,14 @@
 package com.javainiai.chefskiss.data.recipe
 
+import com.javainiai.chefskiss.data.ingredient.Ingredient
 import kotlinx.coroutines.flow.Flow
 
 interface RecipesRepository {
     fun getAllRecipesStream(): Flow<List<Recipe>>
     fun getRecipeStream(id: Int): Flow<Recipe?>
     fun getRecentRecipes(): Flow<List<Recipe>>
-    suspend fun insertRecipe(recipe: Recipe)
+    suspend fun insertRecipe(recipe: Recipe): Long
+    suspend fun insertRecipeWithIngredients(recipe: Recipe, ingredients: List<Ingredient>)
     suspend fun deleteRecipe(recipe: Recipe)
     suspend fun updateRecipe(recipe: Recipe)
 }

--- a/app/src/main/java/com/javainiai/chefskiss/data/tag/TagDao.kt
+++ b/app/src/main/java/com/javainiai/chefskiss/data/tag/TagDao.kt
@@ -7,6 +7,7 @@ import androidx.room.OnConflictStrategy
 import androidx.room.Query
 import androidx.room.Update
 import kotlinx.coroutines.flow.Flow
+
 @Dao
 interface TagDao {
     @Insert(onConflict = OnConflictStrategy.IGNORE)

--- a/app/src/main/java/com/javainiai/chefskiss/ui/AppViewModelProvider.kt
+++ b/app/src/main/java/com/javainiai/chefskiss/ui/AppViewModelProvider.kt
@@ -6,11 +6,15 @@ import androidx.lifecycle.viewmodel.initializer
 import androidx.lifecycle.viewmodel.viewModelFactory
 import com.javainiai.chefskiss.ChefsKissApplication
 import com.javainiai.chefskiss.ui.homescreen.HomeScreenViewModel
+import com.javainiai.chefskiss.ui.recipescreen.AddRecipeViewModel
 
 object AppViewModelProvider {
     val Factory = viewModelFactory {
         initializer {
             HomeScreenViewModel()
+        }
+        initializer {
+            AddRecipeViewModel(chefsKissApplication().container.recipesRepository)
         }
     }
 }

--- a/app/src/main/java/com/javainiai/chefskiss/ui/ChefsKissApp.kt
+++ b/app/src/main/java/com/javainiai/chefskiss/ui/ChefsKissApp.kt
@@ -29,6 +29,7 @@ fun ChefsKissApp(
     ModalNavigationDrawer(
         modifier = modifier,
         drawerState = drawerState,
+        gesturesEnabled = drawerState.isOpen,
         drawerContent = { ChefsKissDrawerSheet() }) {
         ChefsKissNavHost(drawerState = drawerState, navController = navController)
     }

--- a/app/src/main/java/com/javainiai/chefskiss/ui/homescreen/HomeScreen.kt
+++ b/app/src/main/java/com/javainiai/chefskiss/ui/homescreen/HomeScreen.kt
@@ -41,7 +41,7 @@ import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.unit.dp
 import androidx.lifecycle.viewmodel.compose.viewModel
 import coil.compose.AsyncImage
-import com.javainiai.chefskiss.data.Recipe
+import com.javainiai.chefskiss.data.recipe.Recipe
 import com.javainiai.chefskiss.ui.AppViewModelProvider
 import com.javainiai.chefskiss.ui.navigation.NavigationDestination
 import kotlinx.coroutines.launch
@@ -54,13 +54,19 @@ object HomeScreenDestination : NavigationDestination {
 fun HomeScreen(
     drawerState: DrawerState,
     modifier: Modifier = Modifier,
-    viewModel: HomeScreenViewModel = viewModel(factory = AppViewModelProvider.Factory)
+    viewModel: HomeScreenViewModel = viewModel(factory = AppViewModelProvider.Factory),
+    navigateTo: (String) -> Unit,
 ) {
     val coroutineScope = rememberCoroutineScope()
 
     Scaffold(modifier = modifier,
         topBar = { SearchTopBar(onMenuClick = { coroutineScope.launch { drawerState.open() } }) },
-        bottomBar = { RecipeBottomBar({ /* TODO */ }, { /* TODO */ }, { /* TODO */ }) }
+        bottomBar = {
+            RecipeBottomBar(
+                { /* TODO */ },
+                { /* TODO */ },
+                { /* TODO */ })
+        }
     ) { padding ->
         LazyColumn(contentPadding = padding, horizontalAlignment = Alignment.CenterHorizontally) {
             /* TODO */

--- a/app/src/main/java/com/javainiai/chefskiss/ui/navigation/ChefsKissNavHost.kt
+++ b/app/src/main/java/com/javainiai/chefskiss/ui/navigation/ChefsKissNavHost.kt
@@ -8,6 +8,8 @@ import androidx.navigation.compose.NavHost
 import androidx.navigation.compose.composable
 import com.javainiai.chefskiss.ui.homescreen.HomeScreen
 import com.javainiai.chefskiss.ui.homescreen.HomeScreenDestination
+import com.javainiai.chefskiss.ui.recipescreen.AddRecipeDestination
+import com.javainiai.chefskiss.ui.recipescreen.AddRecipeScreen
 
 @Composable
 fun ChefsKissNavHost(
@@ -21,7 +23,12 @@ fun ChefsKissNavHost(
         modifier = modifier
     ) {
         composable(route = HomeScreenDestination.route) {
-            HomeScreen(drawerState)
+            HomeScreen(drawerState) {
+                navController.navigate(it)
+            }
+        }
+        composable(route = AddRecipeDestination.route) {
+            AddRecipeScreen(navigateBack = { navController.popBackStack() })
         }
     }
 

--- a/app/src/main/java/com/javainiai/chefskiss/ui/recipescreen/AddRecipeScreen.kt
+++ b/app/src/main/java/com/javainiai/chefskiss/ui/recipescreen/AddRecipeScreen.kt
@@ -1,0 +1,324 @@
+package com.javainiai.chefskiss.ui.recipescreen
+
+import android.net.Uri
+import androidx.activity.compose.rememberLauncherForActivityResult
+import androidx.activity.result.contract.ActivityResultContracts
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.text.KeyboardActions
+import androidx.compose.foundation.text.KeyboardOptions
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.ArrowBack
+import androidx.compose.material.icons.filled.Done
+import androidx.compose.material.icons.filled.People
+import androidx.compose.material.icons.filled.Remove
+import androidx.compose.material.icons.filled.Timer
+import androidx.compose.material.icons.filled.Title
+import androidx.compose.material3.Button
+import androidx.compose.material3.Card
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Tab
+import androidx.compose.material3.TabRow
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextField
+import androidx.compose.material3.TopAppBar
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableIntStateOf
+import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.runtime.saveable.rememberSaveable
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.focus.FocusDirection
+import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.platform.LocalFocusManager
+import androidx.compose.ui.text.input.ImeAction
+import androidx.compose.ui.text.input.KeyboardType
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import androidx.lifecycle.viewmodel.compose.viewModel
+import coil.compose.AsyncImage
+import com.javainiai.chefskiss.ui.AppViewModelProvider
+import com.javainiai.chefskiss.ui.navigation.NavigationDestination
+import com.javainiai.chefskiss.ui.theme.ChefsKissTheme
+import kotlinx.coroutines.launch
+
+
+@Preview
+@Composable
+fun AddRecipeScreenPreview() {
+    ChefsKissTheme {
+        AddRecipeScreen({})
+    }
+}
+
+object AddRecipeDestination : NavigationDestination {
+    override val route = "addrecipe"
+}
+
+@Composable
+fun AddRecipeScreen(
+    navigateBack: () -> Unit,
+    viewModel: AddRecipeViewModel = viewModel(factory = AppViewModelProvider.Factory)
+) {
+    val uiState by viewModel.uiState.collectAsState()
+
+    val coroutineScope = rememberCoroutineScope()
+
+    var tabIndex by rememberSaveable {
+        mutableIntStateOf(0)
+    }
+
+    val tabs = listOf("Overview", "Ingredients", "Directions")
+
+    Scaffold(topBar = {
+        AddRecipeTopBar(
+            onBack = navigateBack,
+            onSave = { coroutineScope.launch { if (viewModel.saveToDatabase()) navigateBack() } })
+    }) { padding ->
+        Column(modifier = Modifier.padding(padding)) {
+            TabRow(selectedTabIndex = tabIndex) {
+                tabs.forEachIndexed { index, label ->
+                    Tab(
+                        selected = tabIndex == index,
+                        onClick = { tabIndex = index },
+                        text = { Text(text = label) })
+                }
+            }
+            when (tabIndex) {
+                0 -> RecipeOverview(
+                    selectedImage = uiState.imageUri,
+                    updateSelectedImage = viewModel::updateImageUri,
+                    title = uiState.title,
+                    onTitleChange = viewModel::updateTitle,
+                    cookingTime = uiState.cookingTime,
+                    onCookingTimeChange = { viewModel.updateCookingTime(it) },
+                    servings = uiState.servings,
+                    onServingsChange = { viewModel.updateServings(it) },
+                    modifier = Modifier
+                        .padding(20.dp)
+                        .fillMaxWidth()
+                )
+
+                1 -> RecipeIngredients(
+                    ingredient = uiState.ingredient,
+                    updateIngredient = { viewModel.updateIngredient(it) },
+                    ingredients = uiState.ingredients,
+                    updateIngredients = { viewModel.updateIngredients(it) },
+                    modifier = Modifier
+                        .padding(20.dp)
+                        .fillMaxWidth()
+                )
+
+                2 -> RecipeDirections(
+                    directions = uiState.directions,
+                    onDirectionsChange = { viewModel.updateDirections(it) })
+            }
+        }
+    }
+}
+
+
+@Composable
+fun RecipeOverview(
+    selectedImage: Uri,
+    updateSelectedImage: (Uri) -> Unit,
+    title: String,
+    onTitleChange: (String) -> Unit,
+    cookingTime: String,
+    onCookingTimeChange: (String) -> Unit,
+    servings: String,
+    onServingsChange: (String) -> Unit,
+    modifier: Modifier = Modifier
+) {
+    val galleryLauncher =
+        rememberLauncherForActivityResult(contract = ActivityResultContracts.GetContent()) { uri ->
+            if (uri != null) {
+                updateSelectedImage(uri)
+            }
+        }
+
+    Column(
+        modifier = modifier,
+        verticalArrangement = Arrangement.spacedBy(16.dp),
+        horizontalAlignment = Alignment.CenterHorizontally
+    ) {
+
+        if (selectedImage != Uri.EMPTY) {
+            AsyncImage(
+                model = selectedImage,
+                contentDescription = "Selected image",
+                contentScale = ContentScale.Crop,
+                modifier = Modifier
+                    .size(256.dp)
+                    .clickable { galleryLauncher.launch("image/*") })
+        } else {
+            Button(onClick = { galleryLauncher.launch("image/*") }) {
+                Text(text = "Pick image from gallery")
+            }
+        }
+
+        TextField(
+            value = title,
+            onValueChange = { onTitleChange(it) },
+            label = { Text(text = "Title") },
+            trailingIcon = {
+                Icon(
+                    imageVector = Icons.Default.Title,
+                    contentDescription = "Title"
+                )
+            },
+            keyboardOptions = KeyboardOptions(imeAction = ImeAction.Next)
+        )
+
+        TextField(
+            value = cookingTime,
+            onValueChange = { onCookingTimeChange(it) },
+            label = { Text(text = "Cooking Time (minutes)") },
+            keyboardOptions = KeyboardOptions(
+                keyboardType = KeyboardType.Number,
+                imeAction = ImeAction.Next
+            ),
+            trailingIcon = {
+                Icon(
+                    imageVector = Icons.Default.Timer,
+                    contentDescription = "Cooking time"
+                )
+            }
+        )
+
+        TextField(
+            value = servings,
+            onValueChange = { onServingsChange(it) },
+            label = { Text(text = "Servings") },
+            keyboardOptions = KeyboardOptions(
+                keyboardType = KeyboardType.Number,
+                imeAction = ImeAction.Done
+            ),
+            trailingIcon = {
+                Icon(
+                    imageVector = Icons.Default.People,
+                    contentDescription = "Servings"
+                )
+            }
+        )
+    }
+}
+
+@Composable
+fun RecipeIngredients(
+    ingredient: IngredientDisplay,
+    updateIngredient: (IngredientDisplay) -> Unit,
+    ingredients: List<IngredientDisplay>,
+    updateIngredients: (List<IngredientDisplay>) -> Unit,
+    modifier: Modifier = Modifier
+) {
+    val focusManager = LocalFocusManager.current
+    Column(
+        modifier = modifier,
+        verticalArrangement = Arrangement.spacedBy(16.dp),
+        horizontalAlignment = Alignment.CenterHorizontally
+    ) {
+        TextField(
+            value = ingredient.title,
+            onValueChange = { updateIngredient(ingredient.copy(title = it)) },
+            label = { Text(text = "Ingredient") },
+            keyboardOptions = KeyboardOptions(imeAction = ImeAction.Next)
+        )
+        TextField(
+            value = ingredient.amount,
+            onValueChange = { updateIngredient(ingredient.copy(amount = it)) },
+            label = { Text(text = "Amount") },
+            keyboardOptions = KeyboardOptions(
+                keyboardType = KeyboardType.Number,
+                imeAction = ImeAction.Next
+            )
+        )
+        TextField(
+            value = ingredient.units,
+            onValueChange = { updateIngredient(ingredient.copy(units = it)) },
+            label = { Text(text = "Unit") },
+            keyboardOptions = KeyboardOptions(imeAction = ImeAction.Done),
+            keyboardActions = KeyboardActions(onDone = {
+                updateIngredients(ingredients + ingredient)
+                updateIngredient(IngredientDisplay("", "", ""))
+                focusManager.moveFocus(FocusDirection.Next)
+            })
+        )
+        LazyColumn {
+            items(items = ingredients) {
+                IngredientCard(ingredient = it, onRemove = { updateIngredients(ingredients - it) })
+            }
+        }
+    }
+}
+
+@Composable
+fun IngredientCard(
+    ingredient: IngredientDisplay,
+    onRemove: () -> Unit,
+    modifier: Modifier = Modifier
+) {
+    Card(modifier = modifier) {
+        Row(modifier = Modifier.padding(4.dp), verticalAlignment = Alignment.CenterVertically) {
+            Text(text = "${ingredient.title} ${ingredient.amount} ${ingredient.units}")
+            IconButton(onClick = onRemove) {
+                Icon(imageVector = Icons.Default.Remove, contentDescription = "Remove")
+            }
+        }
+    }
+}
+
+@Composable
+fun RecipeDirections(
+    directions: String,
+    onDirectionsChange: (String) -> Unit,
+    modifier: Modifier = Modifier
+) {
+    TextField(
+        value = directions,
+        onValueChange = { onDirectionsChange(it) },
+        modifier.fillMaxSize(),
+        label = {
+            Text(
+                text = "Enter cooking directions"
+            )
+        })
+}
+
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun AddRecipeTopBar(onBack: () -> Unit, onSave: () -> Unit) {
+    TopAppBar(title = {
+        Row {
+            Spacer(modifier = Modifier.weight(1f))
+            IconButton(onClick = onSave) {
+                Icon(imageVector = Icons.Default.Done, contentDescription = "Done")
+            }
+        }
+    },
+        navigationIcon = {
+            IconButton(onClick = onBack) {
+                Icon(
+                    imageVector = Icons.AutoMirrored.Default.ArrowBack,
+                    contentDescription = "Back"
+                )
+            }
+        }
+    )
+}

--- a/app/src/main/java/com/javainiai/chefskiss/ui/recipescreen/AddRecipeViewModel.kt
+++ b/app/src/main/java/com/javainiai/chefskiss/ui/recipescreen/AddRecipeViewModel.kt
@@ -1,0 +1,152 @@
+package com.javainiai.chefskiss.ui.recipescreen
+
+import android.net.Uri
+import androidx.lifecycle.ViewModel
+import com.javainiai.chefskiss.data.ingredient.Ingredient
+import com.javainiai.chefskiss.data.recipe.Recipe
+import com.javainiai.chefskiss.data.recipe.RecipesRepository
+import com.javainiai.chefskiss.data.tag.Tag
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.update
+
+data class IngredientDisplay(
+    val title: String,
+    val amount: String,
+    val units: String
+)
+
+data class AddRecipeUiState(
+    val title: String,
+    val cookingTime: String,
+    val servings: String,
+    val imageUri: Uri,
+    val ingredient: IngredientDisplay,
+    val ingredients: List<IngredientDisplay>,
+    val tags: List<Tag>,
+    val directions: String
+)
+
+class AddRecipeViewModel(private val recipesRepository: RecipesRepository) : ViewModel() {
+    private var _uiState =
+        MutableStateFlow(
+            AddRecipeUiState(
+                "",
+                "",
+                "",
+                Uri.EMPTY,
+                IngredientDisplay("", "", ""),
+                listOf(),
+                listOf(),
+                ""
+            )
+        )
+    val uiState = _uiState.asStateFlow()
+
+    fun updateTitle(title: String) {
+        _uiState.update { currentState ->
+            currentState.copy(
+                title = title
+            )
+        }
+    }
+
+    fun updateCookingTime(time: String) {
+        _uiState.update { currentState ->
+            currentState.copy(
+                cookingTime = time
+            )
+        }
+    }
+
+    fun updateServings(servings: String) {
+        _uiState.update { currentState ->
+            currentState.copy(
+                servings = servings
+            )
+        }
+    }
+
+    fun updateImageUri(uri: Uri) {
+        _uiState.update { currentState ->
+            currentState.copy(
+                imageUri = uri
+            )
+        }
+    }
+
+    fun updateIngredient(ingredient: IngredientDisplay) {
+        _uiState.update { currentState ->
+            currentState.copy(
+                ingredient = ingredient
+            )
+        }
+    }
+
+    fun updateIngredients(ingredients: List<IngredientDisplay>) {
+        _uiState.update { currentState ->
+            currentState.copy(
+                ingredients = ingredients
+            )
+        }
+    }
+
+    fun updateTags(tags: List<Tag>) {
+        _uiState.update { currentState ->
+            currentState.copy(
+                tags = tags
+            )
+        }
+    }
+
+    fun updateDirections(directions: String) {
+        _uiState.update { currentState ->
+            currentState.copy(
+                directions = directions
+            )
+        }
+    }
+
+    // TODO: show validation messages to the user
+    private fun validateEntries(): Boolean {
+        with(uiState.value) {
+
+        }
+        return true
+    }
+
+    suspend fun saveToDatabase(): Boolean {
+        if (validateEntries()) {
+            with(uiState.value) {
+                val recipe = Recipe(
+                    title = title,
+                    description = directions,
+                    cookingTime = cookingTime.toIntOrNull() ?: 0,
+                    servings = cookingTime.toIntOrNull() ?: 0,
+                    rating = 0,
+                    favorite = false,
+                    imagePath = imageUri
+                )
+
+                val list = mutableListOf<Ingredient>()
+                for (i in ingredients) {
+                    val ingredient = Ingredient(
+                        recipeId = 0,
+                        name = i.title,
+                        size = i.amount.toFloatOrNull() ?: 0f,
+                        unit = i.units,
+                        // TODO: setting allergens in add screen in IngredientDisplay
+                        allergen = false
+                    )
+
+                    list.add(ingredient)
+                }
+
+                recipesRepository.insertRecipeWithIngredients(recipe, list)
+            }
+        } else {
+            return false
+        }
+        return true
+    }
+}


### PR DESCRIPTION
Implemented the recipe adding screen, some changes to the database to make it easier for us to insert/retrieve recipes with ingredients. The screen is very basic for now, but it works, we can improve the design later.

![Screenshot_20240303_205500](https://github.com/dov-vai/ChefsKiss/assets/160327869/6719738d-fad6-41c6-865d-51a9cddf5083)
![Screenshot_20240303_205531](https://github.com/dov-vai/ChefsKiss/assets/160327869/5fa9ee3a-5964-4f32-a915-13c3750e53c3)
![Screenshot_20240303_205540](https://github.com/dov-vai/ChefsKiss/assets/160327869/25c678b0-423c-4507-b4e6-40fda50d6719)
