### PR TITLE
CHEF-28: Recipe display UI

### DIFF
--- a/app/src/main/java/com/javainiai/chefskiss/data/recipe/OfflineRecipesRepository.kt
+++ b/app/src/main/java/com/javainiai/chefskiss/data/recipe/OfflineRecipesRepository.kt
@@ -10,6 +10,9 @@ class OfflineRecipesRepository(
 ) : RecipesRepository {
     override fun getAllRecipesStream(): Flow<List<Recipe>> = recipeDao.getAllRecipes()
     override fun getRecipeStream(id: Int): Flow<Recipe?> = recipeDao.getRecipe(id)
+    override fun getRecipeWithIngredients(id: Int): Flow<RecipeWithIngredients?> =
+        recipeDao.getRecipeWithIngredients(id)
+
     override fun getRecentRecipes(): Flow<List<Recipe>> = recipeDao.getRecentRecipes()
     override suspend fun insertRecipe(recipe: Recipe): Long = recipeDao.insert(recipe)
     override suspend fun insertRecipeWithIngredients(

--- a/app/src/main/java/com/javainiai/chefskiss/data/recipe/RecipeDao.kt
+++ b/app/src/main/java/com/javainiai/chefskiss/data/recipe/RecipeDao.kt
@@ -29,6 +29,10 @@ interface RecipeDao {
     fun getRecipe(id: Int): Flow<Recipe>
 
     @Transaction
+    @Query("SELECT * from recipes WHERE id = :id")
+    fun getRecipeWithIngredients(id: Int): Flow<RecipeWithIngredients>
+
+    @Transaction
     @Query("SELECT * from recipes")
     fun getAllRecipes(): Flow<List<Recipe>>
 

--- a/app/src/main/java/com/javainiai/chefskiss/data/recipe/RecipesRepository.kt
+++ b/app/src/main/java/com/javainiai/chefskiss/data/recipe/RecipesRepository.kt
@@ -6,6 +6,7 @@ import kotlinx.coroutines.flow.Flow
 interface RecipesRepository {
     fun getAllRecipesStream(): Flow<List<Recipe>>
     fun getRecipeStream(id: Int): Flow<Recipe?>
+    fun getRecipeWithIngredients(id: Int): Flow<RecipeWithIngredients?>
     fun getRecentRecipes(): Flow<List<Recipe>>
     suspend fun insertRecipe(recipe: Recipe): Long
     suspend fun insertRecipeWithIngredients(recipe: Recipe, ingredients: List<Ingredient>)

--- a/app/src/main/java/com/javainiai/chefskiss/ui/AppViewModelProvider.kt
+++ b/app/src/main/java/com/javainiai/chefskiss/ui/AppViewModelProvider.kt
@@ -1,12 +1,14 @@
 package com.javainiai.chefskiss.ui
 
 import androidx.lifecycle.ViewModelProvider
+import androidx.lifecycle.createSavedStateHandle
 import androidx.lifecycle.viewmodel.CreationExtras
 import androidx.lifecycle.viewmodel.initializer
 import androidx.lifecycle.viewmodel.viewModelFactory
 import com.javainiai.chefskiss.ChefsKissApplication
 import com.javainiai.chefskiss.ui.homescreen.HomeScreenViewModel
 import com.javainiai.chefskiss.ui.recipescreen.AddRecipeViewModel
+import com.javainiai.chefskiss.ui.recipescreen.RecipeDetailsViewModel
 
 object AppViewModelProvider {
     val Factory = viewModelFactory {
@@ -15,6 +17,12 @@ object AppViewModelProvider {
         }
         initializer {
             AddRecipeViewModel(chefsKissApplication().container.recipesRepository)
+        }
+        initializer {
+            RecipeDetailsViewModel(
+                this.createSavedStateHandle(),
+                chefsKissApplication().container.recipesRepository
+            )
         }
     }
 }

--- a/app/src/main/java/com/javainiai/chefskiss/ui/homescreen/HomeScreen.kt
+++ b/app/src/main/java/com/javainiai/chefskiss/ui/homescreen/HomeScreen.kt
@@ -48,6 +48,7 @@ import coil.compose.AsyncImage
 import com.javainiai.chefskiss.data.recipe.Recipe
 import com.javainiai.chefskiss.ui.AppViewModelProvider
 import com.javainiai.chefskiss.ui.navigation.NavigationDestination
+import com.javainiai.chefskiss.ui.recipescreen.RecipeDetailsDestination
 import kotlinx.coroutines.launch
 
 object HomeScreenDestination : NavigationDestination {
@@ -76,7 +77,11 @@ fun HomeScreen(
     ) { padding ->
         LazyColumn(contentPadding = padding, horizontalAlignment = Alignment.CenterHorizontally) {
             items(items = homeUiState.recipeList) { recipe ->
-                RecipeCard(recipe = recipe, modifier = Modifier.padding(8.dp))
+                RecipeCard(
+                    recipe = recipe,
+                    modifier = Modifier
+                        .padding(8.dp)
+                        .clickable { navigateTo("${RecipeDetailsDestination.route}/${recipe.id}") })
             }
         }
     }

--- a/app/src/main/java/com/javainiai/chefskiss/ui/navigation/ChefsKissNavHost.kt
+++ b/app/src/main/java/com/javainiai/chefskiss/ui/navigation/ChefsKissNavHost.kt
@@ -4,12 +4,16 @@ import androidx.compose.material3.DrawerState
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.navigation.NavHostController
+import androidx.navigation.NavType
 import androidx.navigation.compose.NavHost
 import androidx.navigation.compose.composable
+import androidx.navigation.navArgument
 import com.javainiai.chefskiss.ui.homescreen.HomeScreen
 import com.javainiai.chefskiss.ui.homescreen.HomeScreenDestination
 import com.javainiai.chefskiss.ui.recipescreen.AddRecipeDestination
 import com.javainiai.chefskiss.ui.recipescreen.AddRecipeScreen
+import com.javainiai.chefskiss.ui.recipescreen.RecipeDetailsDestination
+import com.javainiai.chefskiss.ui.recipescreen.RecipeDetailsScreen
 
 @Composable
 fun ChefsKissNavHost(
@@ -29,6 +33,14 @@ fun ChefsKissNavHost(
         }
         composable(route = AddRecipeDestination.route) {
             AddRecipeScreen(navigateBack = { navController.popBackStack() })
+        }
+        composable(
+            route = RecipeDetailsDestination.routeWithArgs,
+            arguments = listOf(navArgument(RecipeDetailsDestination.recipeIdArg) {
+                type = NavType.IntType
+            })
+        ) {
+            RecipeDetailsScreen(navigateBack = { navController.popBackStack() })
         }
     }
 

--- a/app/src/main/java/com/javainiai/chefskiss/ui/recipescreen/RecipeDetailsScreen.kt
+++ b/app/src/main/java/com/javainiai/chefskiss/ui/recipescreen/RecipeDetailsScreen.kt
@@ -1,0 +1,311 @@
+package com.javainiai.chefskiss.ui.recipescreen
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.ArrowBack
+import androidx.compose.material.icons.automirrored.filled.MenuBook
+import androidx.compose.material.icons.filled.Delete
+import androidx.compose.material.icons.filled.Edit
+import androidx.compose.material.icons.filled.Favorite
+import androidx.compose.material.icons.filled.FavoriteBorder
+import androidx.compose.material.icons.filled.People
+import androidx.compose.material.icons.filled.RestaurantMenu
+import androidx.compose.material.icons.filled.ShoppingBasket
+import androidx.compose.material.icons.filled.Star
+import androidx.compose.material.icons.filled.StarBorder
+import androidx.compose.material.icons.filled.Timer
+import androidx.compose.material3.AlertDialog
+import androidx.compose.material3.BottomAppBar
+import androidx.compose.material3.ButtonDefaults
+import androidx.compose.material3.Card
+import androidx.compose.material3.Checkbox
+import androidx.compose.material3.Divider
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.FilledTonalButton
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Surface
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.material3.TopAppBar
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import androidx.lifecycle.viewmodel.compose.viewModel
+import coil.compose.AsyncImage
+import com.javainiai.chefskiss.data.ingredient.Ingredient
+import com.javainiai.chefskiss.data.recipe.Recipe
+import com.javainiai.chefskiss.ui.AppViewModelProvider
+import com.javainiai.chefskiss.ui.navigation.NavigationDestination
+import kotlinx.coroutines.launch
+
+object RecipeDetailsDestination : NavigationDestination {
+    override val route = "recipe_display"
+    const val recipeIdArg = "recipeId"
+    val routeWithArgs = "$route/{$recipeIdArg}"
+}
+
+@Composable
+fun RecipeDetailsScreen(
+    navigateBack: () -> Unit,
+    viewModel: RecipeDetailsViewModel = viewModel(factory = AppViewModelProvider.Factory)
+) {
+    val uiState by viewModel.uiState.collectAsState()
+    val coroutineScope = rememberCoroutineScope()
+
+    Scaffold(
+        topBar = {
+            RecipeTopBar(
+                isFavorite = uiState.recipe.favorite,
+                onBack = navigateBack,
+                onDelete = {
+                    coroutineScope.launch {
+                        viewModel.deleteRecipe()
+                        navigateBack()
+                    }
+                }
+            )
+        },
+        bottomBar = { RecipeBottomBar(viewModel.screenIndex, viewModel::updateScreenIndex) }
+    ) { padding ->
+        when (viewModel.screenIndex) {
+            0 -> RecipeAbout(recipe = uiState.recipe, modifier = Modifier.padding(padding))
+            1 -> RecipeIngredients(
+                ingredients = uiState.ingredients,
+                modifier = Modifier.padding(padding)
+            )
+
+            2 -> RecipeInstructions(recipe = uiState.recipe, modifier = Modifier.padding(padding))
+        }
+    }
+}
+
+@Composable
+fun RecipeAbout(recipe: Recipe, modifier: Modifier = Modifier) {
+    Surface(modifier = modifier) {
+        Column(
+            modifier = Modifier.padding(16.dp),
+            verticalArrangement = Arrangement.spacedBy(8.dp)
+        ) {
+            AsyncImage(
+                model = recipe.imagePath,
+                contentDescription = null,
+                contentScale = ContentScale.Crop,
+                modifier = Modifier
+                    .size(256.dp)
+                    .clip(RoundedCornerShape(16.dp))
+                    .align(alignment = Alignment.CenterHorizontally)
+            )
+            Row {
+                Spacer(modifier = Modifier.weight(1f))
+                repeat(recipe.rating) {
+                    Icon(imageVector = Icons.Default.Star, contentDescription = null)
+                }
+                repeat(5 - recipe.rating) {
+                    Icon(imageVector = Icons.Default.StarBorder, contentDescription = null)
+                }
+            }
+            Divider(modifier = Modifier.padding(10.dp))
+            Row {
+                Icon(
+                    imageVector = Icons.Default.Timer,
+                    contentDescription = "Cooking time",
+                    modifier = Modifier.padding(end = 4.dp)
+                )
+                Text(text = "Cooking time")
+                Spacer(modifier = Modifier.weight(1f))
+                Text(
+                    text = String.format(
+                        "%02d:%02d",
+                        recipe.cookingTime / 60,
+                        recipe.cookingTime % 60
+                    )
+                )
+            }
+            Row {
+                Icon(
+                    imageVector = Icons.Default.People,
+                    contentDescription = "Cooking time",
+                    modifier = Modifier.padding(end = 4.dp)
+                )
+                Text(text = "Serving size")
+                Spacer(modifier = Modifier.weight(1f))
+                Text(text = recipe.servings.toString())
+            }
+        }
+    }
+}
+
+@Composable
+fun IngredientCard(ingredient: Ingredient, modifier: Modifier = Modifier) {
+    var checked by remember {
+        mutableStateOf(false)
+    }
+
+    Card(modifier = modifier) {
+        Row(modifier = Modifier.padding(8.dp), verticalAlignment = Alignment.CenterVertically) {
+            Text(
+                text = "${ingredient.name} ${ingredient.size} ${ingredient.unit}",
+                fontSize = 20.sp
+            )
+            Spacer(modifier = Modifier.weight(1f))
+            Checkbox(checked = checked, onCheckedChange = { checked = !checked })
+        }
+    }
+}
+
+@Composable
+fun RecipeIngredients(ingredients: List<Ingredient>, modifier: Modifier = Modifier) {
+    Surface(modifier = modifier) {
+        LazyColumn {
+            items(ingredients) {
+                IngredientCard(
+                    ingredient = it, modifier = Modifier
+                        .fillMaxWidth()
+                        .padding(16.dp)
+                )
+            }
+        }
+    }
+}
+
+@Composable
+fun RecipeInstructions(recipe: Recipe, modifier: Modifier = Modifier) {
+    Surface(modifier = modifier) {
+        Text(
+            text = recipe.description,
+            modifier = Modifier
+                .verticalScroll(rememberScrollState())
+                .padding(16.dp),
+            fontSize = 24.sp
+        )
+    }
+}
+
+
+data class RecipeScreen(
+    val title: String,
+    val icon: ImageVector
+)
+
+@Composable
+fun RecipeBottomBar(screenIndex: Int, updateScreen: (Int) -> Unit, modifier: Modifier = Modifier) {
+    val screens = listOf(
+        RecipeScreen("About", Icons.Default.RestaurantMenu),
+        RecipeScreen("Ingredients", Icons.Default.ShoppingBasket),
+        RecipeScreen("Directions", Icons.AutoMirrored.Default.MenuBook)
+    )
+    BottomAppBar(modifier = modifier) {
+        Row(modifier = Modifier.fillMaxWidth(), horizontalArrangement = Arrangement.SpaceEvenly) {
+            screens.forEachIndexed { i, screen ->
+                Column(horizontalAlignment = Alignment.CenterHorizontally) {
+                    FilledTonalButton(
+                        onClick = { updateScreen(i) },
+                        colors = ButtonDefaults.filledTonalButtonColors(
+                            containerColor =
+                            if (screenIndex == i) MaterialTheme.colorScheme.secondaryContainer
+                            else MaterialTheme.colorScheme.background
+                        )
+                    ) {
+                        Icon(imageVector = screen.icon, contentDescription = screen.title)
+                    }
+                    Text(text = screen.title)
+                }
+            }
+        }
+    }
+}
+
+@Composable
+fun ConfirmationDialog(
+    onDismiss: () -> Unit,
+    onConfirm: () -> Unit,
+    onDismissRequest: () -> Unit,
+    text: @Composable () -> Unit,
+    modifier: Modifier = Modifier
+) {
+    AlertDialog(onDismissRequest = onDismissRequest, confirmButton = {
+        TextButton(onClick = onConfirm) {
+            Text(text = "Confirm")
+        }
+    }, dismissButton = {
+        TextButton(onClick = onDismiss) {
+            Text(text = "Dismiss")
+        }
+    },
+        text = text
+    )
+}
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun RecipeTopBar(isFavorite: Boolean, onBack: () -> Unit, onDelete: () -> Unit) {
+    var showDialog by remember {
+        mutableStateOf(false)
+    }
+
+    if (showDialog) {
+        ConfirmationDialog(
+            onDismiss = { showDialog = false },
+            onConfirm = {
+                showDialog = false
+                onDelete()
+            },
+            onDismissRequest = { showDialog = false },
+            text = { Text("Are you sure that you want to delete this recipe? (Can't be recovered)") })
+    }
+
+    TopAppBar(
+        navigationIcon = {
+            IconButton(onClick = onBack) {
+                Icon(
+                    imageVector = Icons.AutoMirrored.Default.ArrowBack,
+                    contentDescription = "Back"
+                )
+            }
+        },
+        title = {
+            Row {
+                Spacer(modifier = Modifier.weight(1f))
+                IconButton(onClick = { /*TODO*/ }) {
+                    Icon(imageVector = Icons.Default.Timer, contentDescription = "Timer")
+                }
+                IconButton(onClick = { /*TODO*/ }) {
+                    Icon(
+                        imageVector = if (isFavorite) Icons.Default.Favorite else Icons.Default.FavoriteBorder,
+                        contentDescription = "Favorite"
+                    )
+                }
+                IconButton(onClick = { /*TODO*/ }) {
+                    Icon(imageVector = Icons.Default.Edit, contentDescription = "Edit")
+                }
+                IconButton(onClick = { showDialog = true }) {
+                    Icon(imageVector = Icons.Default.Delete, contentDescription = "Delete")
+                }
+            }
+        })
+}

--- a/app/src/main/java/com/javainiai/chefskiss/ui/recipescreen/RecipeDetailsViewModel.kt
+++ b/app/src/main/java/com/javainiai/chefskiss/ui/recipescreen/RecipeDetailsViewModel.kt
@@ -1,0 +1,58 @@
+package com.javainiai.chefskiss.ui.recipescreen
+
+import android.net.Uri
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableIntStateOf
+import androidx.compose.runtime.setValue
+import androidx.lifecycle.SavedStateHandle
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.javainiai.chefskiss.data.ingredient.Ingredient
+import com.javainiai.chefskiss.data.recipe.Recipe
+import com.javainiai.chefskiss.data.recipe.RecipesRepository
+import kotlinx.coroutines.flow.SharingStarted
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.filterNotNull
+import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.flow.stateIn
+
+data class RecipeDisplayUiState(
+    val recipe: Recipe,
+    val ingredients: List<Ingredient>
+)
+
+class RecipeDetailsViewModel(
+    savedStateHandle: SavedStateHandle,
+    private val recipesRepository: RecipesRepository
+) : ViewModel() {
+    private val recipeId: Int = checkNotNull(savedStateHandle[RecipeDetailsDestination.recipeIdArg])
+
+    val uiState: StateFlow<RecipeDisplayUiState> = recipesRepository
+        .getRecipeWithIngredients(recipeId)
+        .filterNotNull()
+        .map { RecipeDisplayUiState(recipe = it.recipe, ingredients = it.ingredients) }
+        .stateIn(
+            scope = viewModelScope,
+            started = SharingStarted.WhileSubscribed(TIMEOUT_MILLIS),
+            initialValue = RecipeDisplayUiState(
+                Recipe(0, "", "", 0, 0, 0, false, Uri.EMPTY),
+                listOf()
+            )
+        )
+
+
+    var screenIndex by mutableIntStateOf(0)
+        private set
+
+    fun updateScreenIndex(index: Int) {
+        screenIndex = index
+    }
+
+    suspend fun deleteRecipe() {
+        recipesRepository.deleteRecipe(uiState.value.recipe)
+    }
+
+    companion object {
+        private const val TIMEOUT_MILLIS = 5_000L
+    }
+}


### PR DESCRIPTION
Implement the recipe display UI with some changes to the initial design. It can still be improved later on. Loads the recipe and ingredients from the database. Removing the recipe from the database works from this screen.

![Screenshot_20240304_195348](https://github.com/dov-vai/ChefsKiss/assets/160327869/baa2469b-b3fb-4558-b3dc-e42404ba1703)
![Screenshot_20240304_195358](https://github.com/dov-vai/ChefsKiss/assets/160327869/96f7cee1-6704-4302-8b9c-90d437f5acdf)
