### PR TITLE
CHEF-42: Fix double back bug

### DIFF
--- a/app/src/main/java/com/javainiai/chefskiss/ui/navigation/ChefsKissNavHost.kt
+++ b/app/src/main/java/com/javainiai/chefskiss/ui/navigation/ChefsKissNavHost.kt
@@ -32,7 +32,7 @@ fun ChefsKissNavHost(
             }
         }
         composable(route = AddRecipeDestination.route) {
-            AddRecipeScreen(navigateBack = { navController.popBackStack() })
+            AddRecipeScreen(navigateBack = { navController.navigateUp() })
         }
         composable(
             route = RecipeDetailsDestination.routeWithArgs,
@@ -40,7 +40,7 @@ fun ChefsKissNavHost(
                 type = NavType.IntType
             })
         ) {
-            RecipeDetailsScreen(navigateBack = { navController.popBackStack() })
+            RecipeDetailsScreen(navigateBack = { navController.navigateUp() })
         }
     }
 


### PR DESCRIPTION
Use navigateUp instead of popBackStack when implementing back buttons, now it behaves correctly and doesn't return to a blank screen.