### PR TITLE
CHEF-5: Recipe tagging

### DIFF
--- a/app/src/main/java/com/javainiai/chefskiss/data/AppContainer.kt
+++ b/app/src/main/java/com/javainiai/chefskiss/data/AppContainer.kt
@@ -1,28 +1,16 @@
 package com.javainiai.chefskiss.data
 
 import android.content.Context
-import com.javainiai.chefskiss.data.ingredient.IngredientsRepository
-import com.javainiai.chefskiss.data.ingredient.OfflineIngredientsRepository
 import com.javainiai.chefskiss.data.recipe.OfflineRecipesRepository
 import com.javainiai.chefskiss.data.recipe.RecipesRepository
-import com.javainiai.chefskiss.data.tag.OfflineTagsRepository
-import com.javainiai.chefskiss.data.tag.TagsRepository
 
 interface AppContainer {
     val recipesRepository: RecipesRepository
-    val ingredientsRepository: IngredientsRepository
-    val tagsRepository: TagsRepository
 }
 
 class ChefsKissAppContainer(private val context: Context) : AppContainer {
     override val recipesRepository: RecipesRepository by lazy {
         val database = RecipeDatabase.getDatabase(context)
-        OfflineRecipesRepository(database.RecipeDao(), database.IngredientDao())
-    }
-    override val ingredientsRepository: IngredientsRepository by lazy {
-        OfflineIngredientsRepository(RecipeDatabase.getDatabase(context).IngredientDao())
-    }
-    override val tagsRepository: TagsRepository by lazy {
-        OfflineTagsRepository(RecipeDatabase.getDatabase(context).TagDao())
+        OfflineRecipesRepository(database.RecipeDao(), database.IngredientDao(), database.TagDao())
     }
 }

--- a/app/src/main/java/com/javainiai/chefskiss/data/RecipeDatabase.kt
+++ b/app/src/main/java/com/javainiai/chefskiss/data/RecipeDatabase.kt
@@ -11,6 +11,7 @@ import com.javainiai.chefskiss.data.ingredient.Ingredient
 import com.javainiai.chefskiss.data.ingredient.IngredientDao
 import com.javainiai.chefskiss.data.recipe.Recipe
 import com.javainiai.chefskiss.data.recipe.RecipeDao
+import com.javainiai.chefskiss.data.recipe.RecipeTagCrossRef
 import com.javainiai.chefskiss.data.tag.Tag
 import com.javainiai.chefskiss.data.tag.TagDao
 
@@ -28,7 +29,7 @@ class Converters {
 
 
 @Database(
-    entities = [Recipe::class, Ingredient::class, Tag::class],
+    entities = [Recipe::class, Ingredient::class, Tag::class, RecipeTagCrossRef::class],
     version = 1,
     exportSchema = false
 )

--- a/app/src/main/java/com/javainiai/chefskiss/data/ingredient/Ingredient.kt
+++ b/app/src/main/java/com/javainiai/chefskiss/data/ingredient/Ingredient.kt
@@ -19,9 +19,9 @@ import com.javainiai.chefskiss.data.recipe.Recipe
 )
 data class Ingredient(
     @PrimaryKey(autoGenerate = true)
-    val id: Int = 0,
+    val id: Long = 0,
     @ColumnInfo(index = true)
-    val recipeId: Int,
+    val recipeId: Long,
     val name: String,
     val size: Float,
     val unit: String

--- a/app/src/main/java/com/javainiai/chefskiss/data/ingredient/IngredientDao.kt
+++ b/app/src/main/java/com/javainiai/chefskiss/data/ingredient/IngredientDao.kt
@@ -20,11 +20,11 @@ interface IngredientDao {
     suspend fun delete(item: Ingredient)
 
     @Query("SELECT * from ingredients WHERE id = :id")
-    fun getIngredient(id: Int): Flow<Ingredient>
+    fun getIngredient(id: Long): Flow<Ingredient>
 
     @Query("SELECT * from ingredients ORDER BY name ASC")
     fun getAllIngredients(): Flow<List<Ingredient>>
 
     @Query("SELECT * from ingredients WHERE recipeId = :recipeId")
-    fun getAllRecipeIngredients(recipeId: Int): Flow<List<Ingredient>>
+    fun getAllRecipeIngredients(recipeId: Long): Flow<List<Ingredient>>
 }

--- a/app/src/main/java/com/javainiai/chefskiss/data/ingredient/IngredientsRepository.kt
+++ b/app/src/main/java/com/javainiai/chefskiss/data/ingredient/IngredientsRepository.kt
@@ -4,8 +4,8 @@ import kotlinx.coroutines.flow.Flow
 
 interface IngredientsRepository {
     fun getAllIngredientsStream(): Flow<List<Ingredient>>
-    fun getIngredientStream(id: Int): Flow<Ingredient?>
-    fun getAllRecipeIngredients(recipeId: Int): Flow<List<Ingredient>>
+    fun getIngredientStream(id: Long): Flow<Ingredient?>
+    fun getAllRecipeIngredients(recipeId: Long): Flow<List<Ingredient>>
     suspend fun insertIngredient(ingredient: Ingredient)
     suspend fun deleteIngredient(ingredient: Ingredient)
     suspend fun updateIngredient(ingredient: Ingredient)

--- a/app/src/main/java/com/javainiai/chefskiss/data/ingredient/OfflineIngredientsRepository.kt
+++ b/app/src/main/java/com/javainiai/chefskiss/data/ingredient/OfflineIngredientsRepository.kt
@@ -7,10 +7,10 @@ class OfflineIngredientsRepository(private val ingredientDao: IngredientDao) :
     override fun getAllIngredientsStream(): Flow<List<Ingredient>> =
         ingredientDao.getAllIngredients()
 
-    override fun getIngredientStream(id: Int): Flow<Ingredient?> = ingredientDao.getIngredient(id)
+    override fun getIngredientStream(id: Long): Flow<Ingredient?> = ingredientDao.getIngredient(id)
     override suspend fun insertIngredient(ingredient: Ingredient) = ingredientDao.insert(ingredient)
     override suspend fun deleteIngredient(ingredient: Ingredient) = ingredientDao.delete(ingredient)
     override suspend fun updateIngredient(ingredient: Ingredient) = ingredientDao.update(ingredient)
-    override fun getAllRecipeIngredients(recipeId: Int): Flow<List<Ingredient>> =
+    override fun getAllRecipeIngredients(recipeId: Long): Flow<List<Ingredient>> =
         ingredientDao.getAllRecipeIngredients(recipeId)
 }

--- a/app/src/main/java/com/javainiai/chefskiss/data/recipe/OfflineRecipesRepository.kt
+++ b/app/src/main/java/com/javainiai/chefskiss/data/recipe/OfflineRecipesRepository.kt
@@ -2,16 +2,23 @@ package com.javainiai.chefskiss.data.recipe
 
 import com.javainiai.chefskiss.data.ingredient.Ingredient
 import com.javainiai.chefskiss.data.ingredient.IngredientDao
+import com.javainiai.chefskiss.data.tag.Tag
+import com.javainiai.chefskiss.data.tag.TagDao
 import kotlinx.coroutines.flow.Flow
 
 class OfflineRecipesRepository(
     private val recipeDao: RecipeDao,
-    private val ingredientDao: IngredientDao
+    private val ingredientDao: IngredientDao,
+    private val tagDao: TagDao
 ) : RecipesRepository {
+    override fun getAllTags(): Flow<List<Tag>> = tagDao.getAllTags()
     override fun getAllRecipesStream(): Flow<List<Recipe>> = recipeDao.getAllRecipes()
     override fun getRecipeStream(id: Long): Flow<Recipe?> = recipeDao.getRecipe(id)
     override fun getRecipeWithIngredients(id: Long): Flow<RecipeWithIngredients?> =
         recipeDao.getRecipeWithIngredients(id)
+
+    override fun getRecipeWithTags(id: Long): Flow<RecipeWithTags?> =
+        recipeDao.getRecipeWithTags(id)
 
     override fun getRecentRecipes(): Flow<List<Recipe>> = recipeDao.getRecentRecipes()
     override fun getRecipesByCookingTime(isAsc: Boolean): Flow<List<Recipe>> =
@@ -23,15 +30,22 @@ class OfflineRecipesRepository(
     override fun getRecipesByServings(isAsc: Boolean): Flow<List<Recipe>> =
         recipeDao.getRecipesByServings(isAsc)
 
+    override suspend fun insertTag(tag: Tag): Long = tagDao.insert(tag)
+    override suspend fun deleteTag(tag: Tag) = tagDao.delete(tag)
     override suspend fun insertRecipe(recipe: Recipe): Long = recipeDao.insert(recipe)
-    override suspend fun insertRecipeWithIngredients(
+    override suspend fun insertRecipeWithIngredientsAndTags(
         recipe: Recipe,
-        ingredients: List<Ingredient>
+        ingredients: List<Ingredient>,
+        tags: List<Tag>
     ) {
         val recipeId = insertRecipe(recipe)
 
         for (ingredient in ingredients) {
             ingredientDao.insert(ingredient.copy(recipeId = recipeId))
+        }
+
+        for (tag in tags) {
+            recipeDao.insert(RecipeTagCrossRef(recipeId, tag.id))
         }
     }
 

--- a/app/src/main/java/com/javainiai/chefskiss/data/recipe/OfflineRecipesRepository.kt
+++ b/app/src/main/java/com/javainiai/chefskiss/data/recipe/OfflineRecipesRepository.kt
@@ -9,8 +9,8 @@ class OfflineRecipesRepository(
     private val ingredientDao: IngredientDao
 ) : RecipesRepository {
     override fun getAllRecipesStream(): Flow<List<Recipe>> = recipeDao.getAllRecipes()
-    override fun getRecipeStream(id: Int): Flow<Recipe?> = recipeDao.getRecipe(id)
-    override fun getRecipeWithIngredients(id: Int): Flow<RecipeWithIngredients?> =
+    override fun getRecipeStream(id: Long): Flow<Recipe?> = recipeDao.getRecipe(id)
+    override fun getRecipeWithIngredients(id: Long): Flow<RecipeWithIngredients?> =
         recipeDao.getRecipeWithIngredients(id)
 
     override fun getRecentRecipes(): Flow<List<Recipe>> = recipeDao.getRecentRecipes()
@@ -31,7 +31,7 @@ class OfflineRecipesRepository(
         val recipeId = insertRecipe(recipe)
 
         for (ingredient in ingredients) {
-            ingredientDao.insert(ingredient.copy(recipeId = recipeId.toInt()))
+            ingredientDao.insert(ingredient.copy(recipeId = recipeId))
         }
     }
 

--- a/app/src/main/java/com/javainiai/chefskiss/data/recipe/Recipe.kt
+++ b/app/src/main/java/com/javainiai/chefskiss/data/recipe/Recipe.kt
@@ -7,7 +7,7 @@ import androidx.room.PrimaryKey
 @Entity(tableName = "recipes")
 data class Recipe(
     @PrimaryKey(autoGenerate = true)
-    val id: Int = 0,
+    val id: Long = 0,
     val title: String,
     val description: String,
     val cookingTime: Int,

--- a/app/src/main/java/com/javainiai/chefskiss/data/recipe/RecipeDao.kt
+++ b/app/src/main/java/com/javainiai/chefskiss/data/recipe/RecipeDao.kt
@@ -7,7 +7,6 @@ import androidx.room.OnConflictStrategy
 import androidx.room.Query
 import androidx.room.Transaction
 import androidx.room.Update
-import com.javainiai.chefskiss.data.ingredient.Ingredient
 import kotlinx.coroutines.flow.Flow
 
 @Dao
@@ -15,9 +14,8 @@ interface RecipeDao {
     @Insert(onConflict = OnConflictStrategy.IGNORE)
     suspend fun insert(item: Recipe): Long
 
-    @Transaction
-    @Insert
-    suspend fun insert(item: Recipe, ingredients: List<Ingredient>)
+    @Insert(onConflict = OnConflictStrategy.REPLACE)
+    suspend fun insert(item: RecipeTagCrossRef)
 
     @Update
     suspend fun update(item: Recipe)
@@ -31,6 +29,10 @@ interface RecipeDao {
     @Transaction
     @Query("SELECT * from recipes WHERE id = :id")
     fun getRecipeWithIngredients(id: Long): Flow<RecipeWithIngredients>
+
+    @Transaction
+    @Query("SELECT * from recipes WHERE id = :id")
+    fun getRecipeWithTags(id: Long): Flow<RecipeWithTags>
 
     @Query("SELECT * from recipes")
     fun getAllRecipes(): Flow<List<Recipe>>

--- a/app/src/main/java/com/javainiai/chefskiss/data/recipe/RecipeDao.kt
+++ b/app/src/main/java/com/javainiai/chefskiss/data/recipe/RecipeDao.kt
@@ -26,11 +26,11 @@ interface RecipeDao {
     suspend fun delete(item: Recipe)
 
     @Query("SELECT * from recipes WHERE id = :id")
-    fun getRecipe(id: Int): Flow<Recipe>
+    fun getRecipe(id: Long): Flow<Recipe>
 
     @Transaction
     @Query("SELECT * from recipes WHERE id = :id")
-    fun getRecipeWithIngredients(id: Int): Flow<RecipeWithIngredients>
+    fun getRecipeWithIngredients(id: Long): Flow<RecipeWithIngredients>
 
     @Query("SELECT * from recipes")
     fun getAllRecipes(): Flow<List<Recipe>>

--- a/app/src/main/java/com/javainiai/chefskiss/data/recipe/RecipeTagCrossRef.kt
+++ b/app/src/main/java/com/javainiai/chefskiss/data/recipe/RecipeTagCrossRef.kt
@@ -1,0 +1,32 @@
+package com.javainiai.chefskiss.data.recipe
+
+import androidx.room.ColumnInfo
+import androidx.room.Entity
+import androidx.room.ForeignKey
+import com.javainiai.chefskiss.data.tag.Tag
+
+@Entity(
+    tableName = "recipes_tags",
+    primaryKeys = ["recipeId", "tagId"],
+    foreignKeys = [
+        ForeignKey(
+            entity = Recipe::class,
+            parentColumns = arrayOf("id"),
+            childColumns = arrayOf("recipeId"),
+            onDelete = ForeignKey.CASCADE,
+            onUpdate = ForeignKey.CASCADE
+        ),
+        ForeignKey(
+            entity = Tag::class,
+            parentColumns = arrayOf("id"),
+            childColumns = arrayOf("tagId"),
+            onDelete = ForeignKey.CASCADE,
+            onUpdate = ForeignKey.CASCADE
+        )
+    ]
+)
+data class RecipeTagCrossRef(
+    val recipeId: Long,
+    @ColumnInfo(index = true)
+    val tagId: Long
+)

--- a/app/src/main/java/com/javainiai/chefskiss/data/recipe/RecipeWithTags.kt
+++ b/app/src/main/java/com/javainiai/chefskiss/data/recipe/RecipeWithTags.kt
@@ -1,0 +1,20 @@
+package com.javainiai.chefskiss.data.recipe
+
+import androidx.room.Embedded
+import androidx.room.Junction
+import androidx.room.Relation
+import com.javainiai.chefskiss.data.tag.Tag
+
+data class RecipeWithTags(
+    @Embedded val recipe: Recipe,
+    @Relation(
+        parentColumn = "id",
+        entityColumn = "id",
+        associateBy = Junction(
+            RecipeTagCrossRef::class,
+            parentColumn = "recipeId",
+            entityColumn = "tagId"
+        )
+    )
+    val tags: List<Tag>
+)

--- a/app/src/main/java/com/javainiai/chefskiss/data/recipe/RecipesRepository.kt
+++ b/app/src/main/java/com/javainiai/chefskiss/data/recipe/RecipesRepository.kt
@@ -5,8 +5,8 @@ import kotlinx.coroutines.flow.Flow
 
 interface RecipesRepository {
     fun getAllRecipesStream(): Flow<List<Recipe>>
-    fun getRecipeStream(id: Int): Flow<Recipe?>
-    fun getRecipeWithIngredients(id: Int): Flow<RecipeWithIngredients?>
+    fun getRecipeStream(id: Long): Flow<Recipe?>
+    fun getRecipeWithIngredients(id: Long): Flow<RecipeWithIngredients?>
     fun getRecentRecipes(): Flow<List<Recipe>>
     fun getRecipesByCookingTime(isAsc: Boolean): Flow<List<Recipe>>
     fun getRecipesByRating(isAsc: Boolean): Flow<List<Recipe>>

--- a/app/src/main/java/com/javainiai/chefskiss/data/recipe/RecipesRepository.kt
+++ b/app/src/main/java/com/javainiai/chefskiss/data/recipe/RecipesRepository.kt
@@ -1,18 +1,28 @@
 package com.javainiai.chefskiss.data.recipe
 
 import com.javainiai.chefskiss.data.ingredient.Ingredient
+import com.javainiai.chefskiss.data.tag.Tag
 import kotlinx.coroutines.flow.Flow
 
 interface RecipesRepository {
+    fun getAllTags(): Flow<List<Tag>>
     fun getAllRecipesStream(): Flow<List<Recipe>>
     fun getRecipeStream(id: Long): Flow<Recipe?>
     fun getRecipeWithIngredients(id: Long): Flow<RecipeWithIngredients?>
+    fun getRecipeWithTags(id: Long): Flow<RecipeWithTags?>
     fun getRecentRecipes(): Flow<List<Recipe>>
     fun getRecipesByCookingTime(isAsc: Boolean): Flow<List<Recipe>>
     fun getRecipesByRating(isAsc: Boolean): Flow<List<Recipe>>
     fun getRecipesByServings(isAsc: Boolean): Flow<List<Recipe>>
+    suspend fun insertTag(tag: Tag): Long
+    suspend fun deleteTag(tag: Tag)
     suspend fun insertRecipe(recipe: Recipe): Long
-    suspend fun insertRecipeWithIngredients(recipe: Recipe, ingredients: List<Ingredient>)
+    suspend fun insertRecipeWithIngredientsAndTags(
+        recipe: Recipe,
+        ingredients: List<Ingredient>,
+        tags: List<Tag>
+    )
+
     suspend fun deleteRecipe(recipe: Recipe)
     suspend fun updateRecipe(recipe: Recipe)
 }

--- a/app/src/main/java/com/javainiai/chefskiss/data/tag/OfflineTagsRepository.kt
+++ b/app/src/main/java/com/javainiai/chefskiss/data/tag/OfflineTagsRepository.kt
@@ -4,11 +4,8 @@ import kotlinx.coroutines.flow.Flow
 
 class OfflineTagsRepository(private val tagDao: TagDao) : TagsRepository {
     override fun getAllTagsStream(): Flow<List<Tag>> = tagDao.getAllTags()
-    override fun getTagStream(id: Int): Flow<Tag?> = tagDao.getTag(id)
-    override fun getAllRecipeTags(recipeId: Int): Flow<List<Tag>> =
-        tagDao.getAllRecipeTags(recipeId)
-
-    override suspend fun insertTag(tag: Tag) = tagDao.insert(tag)
+    override fun getTagStream(id: Long): Flow<Tag?> = tagDao.getTag(id)
+    override suspend fun insertTag(tag: Tag): Long = tagDao.insert(tag)
     override suspend fun deleteTag(tag: Tag) = tagDao.delete(tag)
     override suspend fun updateTag(tag: Tag) = tagDao.update(tag)
 }

--- a/app/src/main/java/com/javainiai/chefskiss/data/tag/Tag.kt
+++ b/app/src/main/java/com/javainiai/chefskiss/data/tag/Tag.kt
@@ -6,7 +6,6 @@ import androidx.room.PrimaryKey
 @Entity(tableName = "tags")
 data class Tag(
     @PrimaryKey(autoGenerate = true)
-    val id: Int = 0,
-    val recipeId: Int,
+    val id: Long = 0,
     val title: String
 )

--- a/app/src/main/java/com/javainiai/chefskiss/data/tag/TagDao.kt
+++ b/app/src/main/java/com/javainiai/chefskiss/data/tag/TagDao.kt
@@ -5,13 +5,14 @@ import androidx.room.Delete
 import androidx.room.Insert
 import androidx.room.OnConflictStrategy
 import androidx.room.Query
+import androidx.room.Transaction
 import androidx.room.Update
 import kotlinx.coroutines.flow.Flow
 
 @Dao
 interface TagDao {
     @Insert(onConflict = OnConflictStrategy.IGNORE)
-    suspend fun insert(item: Tag)
+    suspend fun insert(item: Tag): Long
 
     @Update
     suspend fun update(item: Tag)
@@ -20,11 +21,12 @@ interface TagDao {
     suspend fun delete(item: Tag)
 
     @Query("SELECT * from tags WHERE id = :id")
-    fun getTag(id: Int): Flow<Tag>
+    fun getTag(id: Long): Flow<Tag>
 
     @Query("SELECT * from tags ORDER BY title ASC")
     fun getAllTags(): Flow<List<Tag>>
 
-    @Query("SELECT * from tags WHERE recipeId = :recipeId")
-    fun getAllRecipeTags(recipeId: Int): Flow<List<Tag>>
+    @Transaction
+    @Query("SELECT * from tags WHERE id = :id")
+    fun getTagWithRecipes(id: Long): Flow<TagWithRecipes>
 }

--- a/app/src/main/java/com/javainiai/chefskiss/data/tag/TagWithRecipes.kt
+++ b/app/src/main/java/com/javainiai/chefskiss/data/tag/TagWithRecipes.kt
@@ -1,0 +1,21 @@
+package com.javainiai.chefskiss.data.tag
+
+import androidx.room.Embedded
+import androidx.room.Junction
+import androidx.room.Relation
+import com.javainiai.chefskiss.data.recipe.Recipe
+import com.javainiai.chefskiss.data.recipe.RecipeTagCrossRef
+
+data class TagWithRecipes(
+    @Embedded val tag: Tag,
+    @Relation(
+        parentColumn = "id",
+        entityColumn = "id",
+        associateBy = Junction(
+            RecipeTagCrossRef::class,
+            parentColumn = "tagId",
+            entityColumn = "recipeId"
+        )
+    )
+    val recipes: List<Recipe>
+)

--- a/app/src/main/java/com/javainiai/chefskiss/data/tag/TagsRepository.kt
+++ b/app/src/main/java/com/javainiai/chefskiss/data/tag/TagsRepository.kt
@@ -4,9 +4,8 @@ import kotlinx.coroutines.flow.Flow
 
 interface TagsRepository {
     fun getAllTagsStream(): Flow<List<Tag>>
-    fun getTagStream(id: Int): Flow<Tag?>
-    fun getAllRecipeTags(recipeId: Int): Flow<List<Tag>>
-    suspend fun insertTag(tag: Tag)
+    fun getTagStream(id: Long): Flow<Tag?>
+    suspend fun insertTag(tag: Tag): Long
     suspend fun deleteTag(tag: Tag)
     suspend fun updateTag(tag: Tag)
 }

--- a/app/src/main/java/com/javainiai/chefskiss/ui/navigation/ChefsKissNavHost.kt
+++ b/app/src/main/java/com/javainiai/chefskiss/ui/navigation/ChefsKissNavHost.kt
@@ -37,7 +37,7 @@ fun ChefsKissNavHost(
         composable(
             route = RecipeDetailsDestination.routeWithArgs,
             arguments = listOf(navArgument(RecipeDetailsDestination.recipeIdArg) {
-                type = NavType.IntType
+                type = NavType.LongType
             })
         ) {
             RecipeDetailsScreen(navigateBack = { navController.navigateUp() })

--- a/app/src/main/java/com/javainiai/chefskiss/ui/recipescreen/AddRecipeViewModel.kt
+++ b/app/src/main/java/com/javainiai/chefskiss/ui/recipescreen/AddRecipeViewModel.kt
@@ -2,13 +2,18 @@ package com.javainiai.chefskiss.ui.recipescreen
 
 import android.net.Uri
 import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
 import com.javainiai.chefskiss.data.ingredient.Ingredient
 import com.javainiai.chefskiss.data.recipe.Recipe
 import com.javainiai.chefskiss.data.recipe.RecipesRepository
 import com.javainiai.chefskiss.data.tag.Tag
 import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.SharingStarted
+import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.flow.update
+import kotlinx.coroutines.launch
 
 data class IngredientDisplay(
     val title: String,
@@ -23,8 +28,10 @@ data class AddRecipeUiState(
     val imageUri: Uri,
     val ingredient: IngredientDisplay,
     val ingredients: List<IngredientDisplay>,
+    val tag: String,
     val tags: List<Tag>,
-    val directions: String
+    val directions: String,
+    val tagRemoveMode: Boolean
 )
 
 class AddRecipeViewModel(private val recipesRepository: RecipesRepository) : ViewModel() {
@@ -37,11 +44,21 @@ class AddRecipeViewModel(private val recipesRepository: RecipesRepository) : Vie
                 Uri.EMPTY,
                 IngredientDisplay("", "", ""),
                 listOf(),
+                "",
                 listOf(),
-                ""
+                "",
+                false
             )
         )
     val uiState = _uiState.asStateFlow()
+
+    val tags: StateFlow<List<Tag>> = recipesRepository
+        .getAllTags()
+        .stateIn(
+            scope = viewModelScope,
+            started = SharingStarted.WhileSubscribed(TIMEOUT_MILLIS),
+            initialValue = listOf()
+        )
 
     fun updateTitle(title: String) {
         _uiState.update { currentState ->
@@ -87,6 +104,40 @@ class AddRecipeViewModel(private val recipesRepository: RecipesRepository) : Vie
         _uiState.update { currentState ->
             currentState.copy(
                 ingredients = ingredients
+            )
+        }
+    }
+
+    fun updateTag(tag: String) {
+        _uiState.update { currentState ->
+            currentState.copy(
+                tag = tag
+            )
+        }
+    }
+
+    fun addTag() {
+        // don't add empty tags...
+        if (_uiState.value.tag == "")
+            return
+
+        viewModelScope.launch {
+            recipesRepository.insertTag(Tag(title = _uiState.value.tag))
+            updateTag("")
+        }
+    }
+
+    fun removeTag(tag: Tag) {
+        viewModelScope.launch {
+            recipesRepository.deleteTag(tag)
+            updateTags(_uiState.value.tags - tag)
+        }
+    }
+
+    fun updateTagRemoveMode(mode: Boolean) {
+        _uiState.update { currentState ->
+            currentState.copy(
+                tagRemoveMode = mode
             )
         }
     }
@@ -140,11 +191,15 @@ class AddRecipeViewModel(private val recipesRepository: RecipesRepository) : Vie
                     list.add(ingredient)
                 }
 
-                recipesRepository.insertRecipeWithIngredients(recipe, list)
+                recipesRepository.insertRecipeWithIngredientsAndTags(recipe, list, tags)
             }
         } else {
             return false
         }
         return true
+    }
+
+    companion object {
+        private const val TIMEOUT_MILLIS = 5_000L
     }
 }

--- a/app/src/main/java/com/javainiai/chefskiss/ui/recipescreen/RecipeDetailsViewModel.kt
+++ b/app/src/main/java/com/javainiai/chefskiss/ui/recipescreen/RecipeDetailsViewModel.kt
@@ -25,7 +25,8 @@ class RecipeDetailsViewModel(
     savedStateHandle: SavedStateHandle,
     private val recipesRepository: RecipesRepository
 ) : ViewModel() {
-    private val recipeId: Int = checkNotNull(savedStateHandle[RecipeDetailsDestination.recipeIdArg])
+    private val recipeId: Long =
+        checkNotNull(savedStateHandle[RecipeDetailsDestination.recipeIdArg])
 
     val uiState: StateFlow<RecipeDisplayUiState> = recipesRepository
         .getRecipeWithIngredients(recipeId)


### PR DESCRIPTION
Updated the database so recipe tag removing, loading works with convenience methods and foreign keys set up. Also implemented the recipe tagging UI in the add screen. The user can tap the trash can to enable removal mode so the tags can be removed from the database including the recipe-to-tag references.

![image](https://github.com/dov-vai/ChefsKiss/assets/160327869/f5085b82-67f8-4e79-b60c-73f7383fb8c9)
