### PR TITLE
CHEF-56: Fix image picker crashing app bug

### DIFF
--- a/app/src/main/java/com/javainiai/chefskiss/ui/recipescreen/AddRecipeScreen.kt
+++ b/app/src/main/java/com/javainiai/chefskiss/ui/recipescreen/AddRecipeScreen.kt
@@ -181,7 +181,7 @@ fun RecipeOverview(
     val context = LocalContext.current
 
     val galleryLauncher =
-        rememberLauncherForActivityResult(contract = ActivityResultContracts.GetContent()) {
+        rememberLauncherForActivityResult(contract = ActivityResultContracts.OpenDocument()) {
             it?.let { uri ->
                 context.contentResolver.takePersistableUriPermission(
                     uri,
@@ -204,9 +204,9 @@ fun RecipeOverview(
                 contentScale = ContentScale.Crop,
                 modifier = Modifier
                     .size(128.dp)
-                    .clickable { galleryLauncher.launch("image/*") })
+                    .clickable { galleryLauncher.launch(arrayOf("image/*")) })
         } else {
-            Button(onClick = { galleryLauncher.launch("image/*") }) {
+            Button(onClick = { galleryLauncher.launch(arrayOf("image/*")) }) {
                 Text(text = "Pick image from gallery")
             }
         }


### PR DESCRIPTION
Fixes the bug by replacing the GetContent contract to OpenDocument. Doesn't open the nice image picker UI interface on Android 14 anymore, but at least it works.