### PR TITLE
CHEF-64: Clear snackbars when meal planner and shopping list screens are exited

### DIFF
--- a/app/src/main/java/com/javainiai/chefskiss/ui/mealplanner/MealPlannerScreen.kt
+++ b/app/src/main/java/com/javainiai/chefskiss/ui/mealplanner/MealPlannerScreen.kt
@@ -29,6 +29,7 @@ import androidx.compose.material3.Scaffold
 import androidx.compose.material3.SnackbarHost
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.DisposableEffect
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
@@ -64,8 +65,14 @@ fun MealPlannerScreen(
     val uiState by viewModel.uiState.collectAsState()
     val plannerRecipes by viewModel.plannerRecipes.collectAsState()
     val coroutineScope = rememberCoroutineScope()
-    val undoVisible =
-        uiState.startOfWeek.getDateString() != CalendarUtils.getStartOfWeek().getDateString()
+    val undoVisible = uiState.startOfWeek.getDateString() != CalendarUtils.getStartOfWeek().getDateString()
+
+    DisposableEffect(Unit) {
+        onDispose {
+            viewModel.messageInProgress?.cancel()
+        }
+    }
+
     Scaffold(topBar = {
         MealPlannerTopBar(
             title = uiState.title,

--- a/app/src/main/java/com/javainiai/chefskiss/ui/mealplanner/MealPlannerViewModel.kt
+++ b/app/src/main/java/com/javainiai/chefskiss/ui/mealplanner/MealPlannerViewModel.kt
@@ -43,7 +43,8 @@ class MealPlannerViewModel(private val recipesRepository: RecipesRepository) : V
 
     val snackbarHostState = SnackbarHostState()
 
-    private var messageInProgress: Job? = null
+    var messageInProgress: Job? = null
+        private set
     private fun showMessage(message: String) {
         // cancel in case it hasn't finished so the message can be shown immediately
         messageInProgress?.cancel()

--- a/app/src/main/java/com/javainiai/chefskiss/ui/shoppinglist/ShoppingListScreen.kt
+++ b/app/src/main/java/com/javainiai/chefskiss/ui/shoppinglist/ShoppingListScreen.kt
@@ -25,6 +25,7 @@ import androidx.compose.material3.SnackbarHost
 import androidx.compose.material3.Text
 import androidx.compose.material3.surfaceColorAtElevation
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.DisposableEffect
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
@@ -59,6 +60,12 @@ fun ShoppingList(
     val uiState by viewModel.uiState.collectAsState()
     val checkedIngredients by viewModel.checkedIngredients.collectAsState()
     val coroutineScope = rememberCoroutineScope()
+
+    DisposableEffect(Unit) {
+        onDispose {
+            viewModel.messageInProgress?.cancel()
+        }
+    }
 
     Scaffold(topBar = { ShoppingListTopBar(onMenuClick = { coroutineScope.launch { drawerState.open() } }) },
         snackbarHost = { SnackbarHost(hostState = viewModel.snackbarHostState) }

--- a/app/src/main/java/com/javainiai/chefskiss/ui/shoppinglist/ShoppingListViewModel.kt
+++ b/app/src/main/java/com/javainiai/chefskiss/ui/shoppinglist/ShoppingListViewModel.kt
@@ -50,7 +50,8 @@ class ShoppingListViewModel(private val recipesRepository: RecipesRepository) : 
 
     val snackbarHostState = SnackbarHostState()
 
-    private var messageInProgress: Job? = null
+    var messageInProgress: Job? = null
+        private set
     private fun showMessage(message: String) {
         // cancel in case it hasn't finished so the message can be shown immediately
         messageInProgress?.cancel()


### PR DESCRIPTION
These screen in particular do not get their view models cleared when navigating as their navigation is implemented without using the Android Navigator. So this clears the snackbar messages when the composables of these screens are destroyed instead.