### PR TITLE
CHEF-63: Ingredient units selection

### DIFF
--- a/app/src/main/java/com/javainiai/chefskiss/data/enums/Measurement.kt
+++ b/app/src/main/java/com/javainiai/chefskiss/data/enums/Measurement.kt
@@ -1,0 +1,18 @@
+package com.javainiai.chefskiss.data.enums
+
+/**
+ * @param unit solid units should be represented in grams, and liquid units as milliliters
+ * @param metric marks if unit is metric or imperial
+ * @param weight marks if it measures weight or volume
+ */
+enum class Measurement(
+    val title: String,
+    val unit: Float,
+    val metric: Boolean,
+    val weight: Boolean
+) {
+    Gram("Grams (g)", 1f, true, true),
+    Kilogram("Kilograms (kg)", 1000f, true, true),
+    Milliliter("Mililiters (ml)", 1f, true, false),
+    Liter("Liters (l)", 1000f, true, false)
+}

--- a/app/src/main/java/com/javainiai/chefskiss/data/enums/Measurement.kt
+++ b/app/src/main/java/com/javainiai/chefskiss/data/enums/Measurement.kt
@@ -14,5 +14,10 @@ enum class Measurement(
     Gram("Grams (g)", 1f, true, true),
     Kilogram("Kilograms (kg)", 1000f, true, true),
     Milliliter("Mililiters (ml)", 1f, true, false),
-    Liter("Liters (l)", 1000f, true, false)
+    Liter("Liters (l)", 1000f, true, false),
+    Teaspoon("Teaspoons (t)", 1f, false, false),
+    Tablespoon("Tablespoon (T)", 3f, false, false),
+    Cup("Cup (c)", 48f, false, false),
+    Ounce("Ounce (oz)", 1f, false, true),
+    Pound("Pound (lb)", 16f, false, true)
 }

--- a/app/src/main/java/com/javainiai/chefskiss/data/ingredient/Ingredient.kt
+++ b/app/src/main/java/com/javainiai/chefskiss/data/ingredient/Ingredient.kt
@@ -4,6 +4,7 @@ import androidx.room.ColumnInfo
 import androidx.room.Entity
 import androidx.room.ForeignKey
 import androidx.room.PrimaryKey
+import com.javainiai.chefskiss.data.enums.Measurement
 import com.javainiai.chefskiss.data.recipe.Recipe
 
 @Entity(
@@ -24,5 +25,5 @@ data class Ingredient(
     val recipeId: Long,
     val name: String,
     val size: Float,
-    val unit: String
+    val unit: Measurement
 )

--- a/app/src/main/java/com/javainiai/chefskiss/ui/recipescreen/AddRecipeViewModel.kt
+++ b/app/src/main/java/com/javainiai/chefskiss/ui/recipescreen/AddRecipeViewModel.kt
@@ -6,6 +6,7 @@ import androidx.compose.material3.SnackbarHostState
 import androidx.lifecycle.SavedStateHandle
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
+import com.javainiai.chefskiss.data.enums.Measurement
 import com.javainiai.chefskiss.data.ingredient.Ingredient
 import com.javainiai.chefskiss.data.recipe.Recipe
 import com.javainiai.chefskiss.data.recipe.RecipesRepository
@@ -24,7 +25,7 @@ import kotlinx.coroutines.launch
 data class IngredientDisplay(
     val title: String,
     val amount: String,
-    val units: String
+    val units: Measurement
 )
 
 data class AddRecipeUiState(
@@ -58,7 +59,7 @@ class AddRecipeViewModel(
                 0,
                 false,
                 Uri.EMPTY,
-                IngredientDisplay("", "", ""),
+                IngredientDisplay("", "", Measurement.Gram),
                 null,
                 listOf(),
                 "",
@@ -228,7 +229,7 @@ class AddRecipeViewModel(
                     rating = recipe.rating,
                     favorite = recipe.favorite,
                     imageUri = recipe.imagePath,
-                    ingredient = IngredientDisplay("", "", ""),
+                    ingredient = IngredientDisplay("", "", Measurement.Gram),
                     editingIngredient = null,
                     ingredients = ingredients.map {
                         IngredientDisplay(

--- a/app/src/main/java/com/javainiai/chefskiss/ui/recipescreen/RecipeDetailsScreen.kt
+++ b/app/src/main/java/com/javainiai/chefskiss/ui/recipescreen/RecipeDetailsScreen.kt
@@ -257,6 +257,7 @@ fun RecipeAbout(
                 Spacer(modifier = Modifier.weight(1f))
                 Text(
                     text = String.format(
+                        Locale.getDefault(),
                         "%02d:%02d",
                         recipe.cookingTime / 60,
                         recipe.cookingTime % 60

--- a/app/src/main/java/com/javainiai/chefskiss/ui/recipescreen/RecipeDetailsScreen.kt
+++ b/app/src/main/java/com/javainiai/chefskiss/ui/recipescreen/RecipeDetailsScreen.kt
@@ -316,12 +316,13 @@ fun IngredientCard(
             )
             Text(
                 text = if (ingredient.size == 0f) "" else String.format(
+                    Locale.getDefault(),
                     "%.1f",
                     ingredient.size * multiplier
                 )
             )
             Text(
-                text = ingredient.unit,
+                text = ingredient.unit.title,
                 overflow = TextOverflow.Ellipsis,
                 modifier = Modifier.weight(1f)
             )


### PR DESCRIPTION
Implement selecting units, filtering units by metric/imperial system, units meant for measuring weight and volume. Will be used later for unit conversion.
![image](https://github.com/dov-vai/ChefsKiss/assets/160327869/a200d4a4-a1f5-455a-ae7a-923e58e8fcca)
