### PR TITLE
CHEF-55: Remove snackbar duplicate code

### DIFF
--- a/app/src/main/java/com/javainiai/chefskiss/ui/components/viewmodel/BaseViewModel.kt
+++ b/app/src/main/java/com/javainiai/chefskiss/ui/components/viewmodel/BaseViewModel.kt
@@ -1,0 +1,26 @@
+package com.javainiai.chefskiss.ui.components.viewmodel
+
+import androidx.compose.material3.SnackbarDuration
+import androidx.compose.material3.SnackbarHostState
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.launch
+
+abstract class BaseViewModel : ViewModel() {
+    val snackbarHostState = SnackbarHostState()
+
+    var messageInProgress: Job? = null
+        private set
+
+    protected fun showMessage(message: String) {
+        // cancel in case it hasn't finished so the message can be shown immediately
+        messageInProgress?.cancel()
+        messageInProgress = viewModelScope.launch {
+            snackbarHostState.showSnackbar(
+                message = message,
+                duration = SnackbarDuration.Short
+            )
+        }
+    }
+}

--- a/app/src/main/java/com/javainiai/chefskiss/ui/mealplanner/MealPlannerScreen.kt
+++ b/app/src/main/java/com/javainiai/chefskiss/ui/mealplanner/MealPlannerScreen.kt
@@ -11,7 +11,6 @@ import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.KeyboardArrowLeft
 import androidx.compose.material.icons.automirrored.filled.KeyboardArrowRight
-import androidx.compose.material.icons.automirrored.filled.Undo
 import androidx.compose.material.icons.filled.ArrowDropDown
 import androidx.compose.material.icons.filled.ArrowDropUp
 import androidx.compose.material.icons.filled.Edit

--- a/app/src/main/java/com/javainiai/chefskiss/ui/mealplanner/MealPlannerViewModel.kt
+++ b/app/src/main/java/com/javainiai/chefskiss/ui/mealplanner/MealPlannerViewModel.kt
@@ -1,8 +1,5 @@
 package com.javainiai.chefskiss.ui.mealplanner
 
-import androidx.compose.material3.SnackbarDuration
-import androidx.compose.material3.SnackbarHostState
-import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.javainiai.chefskiss.data.CalendarUtils
 import com.javainiai.chefskiss.data.CalendarUtils.getDate
@@ -10,9 +7,9 @@ import com.javainiai.chefskiss.data.CalendarUtils.getDateString
 import com.javainiai.chefskiss.data.recipe.PlannerRecipeWithRecipe
 import com.javainiai.chefskiss.data.recipe.RecipesRepository
 import com.javainiai.chefskiss.data.recipe.ShopRecipe
+import com.javainiai.chefskiss.ui.components.viewmodel.BaseViewModel
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
-import kotlinx.coroutines.Job
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.StateFlow
@@ -36,7 +33,7 @@ data class MealPlannerUiState(
     val selectedRecipes: List<PlannerRecipeWithRecipe>
 )
 
-class MealPlannerViewModel(private val recipesRepository: RecipesRepository) : ViewModel() {
+class MealPlannerViewModel(private val recipesRepository: RecipesRepository) : BaseViewModel() {
     private var _uiState = MutableStateFlow(
         MealPlannerUiState(
             "",
@@ -47,22 +44,6 @@ class MealPlannerViewModel(private val recipesRepository: RecipesRepository) : V
             listOf()
         )
     )
-
-    val snackbarHostState = SnackbarHostState()
-
-    var messageInProgress: Job? = null
-        private set
-
-    private fun showMessage(message: String) {
-        // cancel in case it hasn't finished so the message can be shown immediately
-        messageInProgress?.cancel()
-        messageInProgress = viewModelScope.launch {
-            snackbarHostState.showSnackbar(
-                message = message,
-                duration = SnackbarDuration.Short
-            )
-        }
-    }
 
     val uiState = _uiState.asStateFlow()
 

--- a/app/src/main/java/com/javainiai/chefskiss/ui/recipescreen/AddRecipeScreen.kt
+++ b/app/src/main/java/com/javainiai/chefskiss/ui/recipescreen/AddRecipeScreen.kt
@@ -434,9 +434,11 @@ fun RecipeIngredients(
                         onClick = { volumeSelected = !volumeSelected },
                         label = { Text(text = "Volume") })
                 }
-                Column(modifier = Modifier
-                    .height(256.dp)
-                    .verticalScroll(rememberScrollState())) {
+                Column(
+                    modifier = Modifier
+                        .height(256.dp)
+                        .verticalScroll(rememberScrollState())
+                ) {
                     Measurement.entries.filter {
                         if (weightSelected && volumeSelected) {
                             it.metric == !imperialSelected

--- a/app/src/main/java/com/javainiai/chefskiss/ui/recipescreen/AddRecipeViewModel.kt
+++ b/app/src/main/java/com/javainiai/chefskiss/ui/recipescreen/AddRecipeViewModel.kt
@@ -1,18 +1,15 @@
 package com.javainiai.chefskiss.ui.recipescreen
 
 import android.net.Uri
-import androidx.compose.material3.SnackbarDuration
-import androidx.compose.material3.SnackbarHostState
 import androidx.lifecycle.SavedStateHandle
-import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.javainiai.chefskiss.data.enums.Measurement
 import com.javainiai.chefskiss.data.ingredient.Ingredient
 import com.javainiai.chefskiss.data.recipe.Recipe
 import com.javainiai.chefskiss.data.recipe.RecipesRepository
 import com.javainiai.chefskiss.data.tag.Tag
+import com.javainiai.chefskiss.ui.components.viewmodel.BaseViewModel
 import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.Job
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.StateFlow
@@ -47,7 +44,7 @@ data class AddRecipeUiState(
 class AddRecipeViewModel(
     savedStateHandle: SavedStateHandle,
     private val recipesRepository: RecipesRepository
-) : ViewModel() {
+) : BaseViewModel() {
     private val editRecipeId: Long? = savedStateHandle[EditRecipeDestination.editRecipeIdArg]
 
     private var _uiState =
@@ -81,20 +78,6 @@ class AddRecipeViewModel(
     init {
         editRecipeId?.let {
             initializeEditRecipe(it)
-        }
-    }
-
-    val snackbarHostState = SnackbarHostState()
-
-    private var messageInProgress: Job? = null
-    private fun showMessage(message: String) {
-        // cancel in case it hasn't finished so the message can be shown immediately
-        messageInProgress?.cancel()
-        messageInProgress = viewModelScope.launch {
-            snackbarHostState.showSnackbar(
-                message = message,
-                duration = SnackbarDuration.Short
-            )
         }
     }
 

--- a/app/src/main/java/com/javainiai/chefskiss/ui/recipescreen/RecipeDetailsViewModel.kt
+++ b/app/src/main/java/com/javainiai/chefskiss/ui/recipescreen/RecipeDetailsViewModel.kt
@@ -1,13 +1,10 @@
 package com.javainiai.chefskiss.ui.recipescreen
 
 import android.net.Uri
-import androidx.compose.material3.SnackbarDuration
-import androidx.compose.material3.SnackbarHostState
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableIntStateOf
 import androidx.compose.runtime.setValue
 import androidx.lifecycle.SavedStateHandle
-import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.javainiai.chefskiss.data.ingredient.Ingredient
 import com.javainiai.chefskiss.data.recipe.PlannerRecipe
@@ -15,7 +12,7 @@ import com.javainiai.chefskiss.data.recipe.Recipe
 import com.javainiai.chefskiss.data.recipe.RecipesRepository
 import com.javainiai.chefskiss.data.recipe.ShopRecipe
 import com.javainiai.chefskiss.data.tag.Tag
-import kotlinx.coroutines.Job
+import com.javainiai.chefskiss.ui.components.viewmodel.BaseViewModel
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.StateFlow
@@ -34,7 +31,7 @@ data class RecipeDisplayUiState(
 class RecipeDetailsViewModel(
     savedStateHandle: SavedStateHandle,
     private val recipesRepository: RecipesRepository
-) : ViewModel() {
+) : BaseViewModel() {
     private val recipeId: Long =
         checkNotNull(savedStateHandle[RecipeDetailsDestination.recipeIdArg])
 
@@ -69,20 +66,6 @@ class RecipeDetailsViewModel(
 
     private var _checkedIngredients = MutableStateFlow(listOf<Ingredient>())
     val checkedIngredients = _checkedIngredients.asStateFlow()
-
-    val snackbarHostState = SnackbarHostState()
-
-    private var messageInProgress: Job? = null
-    private fun showMessage(message: String) {
-        // cancel in case it hasn't finished so the message can be shown immediately
-        messageInProgress?.cancel()
-        messageInProgress = viewModelScope.launch {
-            snackbarHostState.showSnackbar(
-                message = message,
-                duration = SnackbarDuration.Short
-            )
-        }
-    }
 
     var screenIndex by mutableIntStateOf(0)
         private set

--- a/app/src/main/java/com/javainiai/chefskiss/ui/shoppinglist/ShoppingListViewModel.kt
+++ b/app/src/main/java/com/javainiai/chefskiss/ui/shoppinglist/ShoppingListViewModel.kt
@@ -1,15 +1,12 @@
 package com.javainiai.chefskiss.ui.shoppinglist
 
-import androidx.compose.material3.SnackbarDuration
-import androidx.compose.material3.SnackbarHostState
-import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.javainiai.chefskiss.data.recipe.Recipe
 import com.javainiai.chefskiss.data.recipe.RecipeWithIngredients
 import com.javainiai.chefskiss.data.recipe.RecipesRepository
 import com.javainiai.chefskiss.data.recipe.ShopIngredient
 import com.javainiai.chefskiss.data.recipe.ShopRecipe
-import kotlinx.coroutines.Job
+import com.javainiai.chefskiss.ui.components.viewmodel.BaseViewModel
 import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.first
@@ -22,7 +19,7 @@ data class ShoppingListUiState(
     val recipesWithIngredients: List<RecipeWithIngredients>
 )
 
-class ShoppingListViewModel(private val recipesRepository: RecipesRepository) : ViewModel() {
+class ShoppingListViewModel(private val recipesRepository: RecipesRepository) : BaseViewModel() {
 
     val uiState: StateFlow<ShoppingListUiState> =
         recipesRepository
@@ -47,22 +44,6 @@ class ShoppingListViewModel(private val recipesRepository: RecipesRepository) : 
                 started = SharingStarted.WhileSubscribed(TIMEOUT_MILLIS),
                 initialValue = listOf()
             )
-
-    val snackbarHostState = SnackbarHostState()
-
-    var messageInProgress: Job? = null
-        private set
-
-    private fun showMessage(message: String) {
-        // cancel in case it hasn't finished so the message can be shown immediately
-        messageInProgress?.cancel()
-        messageInProgress = viewModelScope.launch {
-            snackbarHostState.showSnackbar(
-                message = message,
-                duration = SnackbarDuration.Short
-            )
-        }
-    }
 
     fun removeRecipe(recipe: Recipe) {
         viewModelScope.launch {


### PR DESCRIPTION
Got rid of the duplicate snackbar code in every ViewModel that needed it by creating an abstract reusable ViewModel class that has the needed methods in place.