### PR TITLE
Recipe tag updating bug

### DIFF
--- a/app/src/main/java/com/javainiai/chefskiss/data/recipe/OfflineRecipesRepository.kt
+++ b/app/src/main/java/com/javainiai/chefskiss/data/recipe/OfflineRecipesRepository.kt
@@ -128,7 +128,7 @@ class OfflineRecipesRepository(
             ingredientDao.delete(ingredient)
         }
         for (tag in tagsToRemove) {
-            tagDao.delete(tag)
+            recipeDao.delete(RecipeTagCrossRef(recipe.id, tag.id))
         }
 
         for (ingredient in ingredients) {
@@ -148,4 +148,5 @@ class OfflineRecipesRepository(
     override suspend fun insertPlannerRecipe(item: PlannerRecipe) = recipeDao.insert(item)
     override suspend fun updatePlannerRecipe(item: PlannerRecipe) = recipeDao.update(item)
     override suspend fun deletePlannerRecipe(item: PlannerRecipe) = recipeDao.delete(item)
+    override suspend fun deleteRecipeTag(item: RecipeTagCrossRef) = recipeDao.delete(item)
 }

--- a/app/src/main/java/com/javainiai/chefskiss/data/recipe/RecipeDao.kt
+++ b/app/src/main/java/com/javainiai/chefskiss/data/recipe/RecipeDao.kt
@@ -29,6 +29,9 @@ interface RecipeDao {
     suspend fun insert(item: PlannerRecipe)
 
     @Delete
+    suspend fun delete(item: RecipeTagCrossRef)
+
+    @Delete
     suspend fun delete(item: ShopIngredient)
 
     @Delete

--- a/app/src/main/java/com/javainiai/chefskiss/data/recipe/RecipesRepository.kt
+++ b/app/src/main/java/com/javainiai/chefskiss/data/recipe/RecipesRepository.kt
@@ -58,4 +58,5 @@ interface RecipesRepository {
     suspend fun insertPlannerRecipe(item: PlannerRecipe)
     suspend fun updatePlannerRecipe(item: PlannerRecipe)
     suspend fun deletePlannerRecipe(item: PlannerRecipe)
+    suspend fun deleteRecipeTag(item: RecipeTagCrossRef)
 }


### PR DESCRIPTION
While monkey testing I found a mistake in updating the recipe tags. Overlooked that I was removing in the tags table itself instead of the cross reference table for the recipe and tags. That is now fixed.